### PR TITLE
Add decision summary carousel

### DIFF
--- a/frontend/src/components/ConversationCard.jsx
+++ b/frontend/src/components/ConversationCard.jsx
@@ -105,6 +105,11 @@ const ConversationCard = ({ item, onFeedback, isAuthenticated, getConfidenceColo
               <CardTitle className="flex items-center gap-2">
                 <span>🎯</span>
                 <span>Your Decision Recommendation</span>
+                {item.version && (
+                  <span className="ml-2 px-2 py-1 bg-primary/10 text-primary text-xs rounded-full">
+                    v{item.version}
+                  </span>
+                )}
               </CardTitle>
             </CardHeader>
             <CardContent className="space-y-6">


### PR DESCRIPTION
## Summary
- track decision versions and active card index
- filter `ai_recommendation` from conversation history
- add `DecisionSummaryCarousel` to browse summaries
- label recommendations with version numbers

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_68542a51112483329a32bab10d4deab2