### PR TITLE
Enhance decision tools

### DIFF
--- a/backend/feedback_summary.py
+++ b/backend/feedback_summary.py
@@ -1,0 +1,37 @@
+import os
+from datetime import datetime, timedelta
+from pymongo import MongoClient
+from .email_service import EmailService
+
+MONGO_URI = os.environ.get("MONGO_URI", "mongodb://localhost:27017")
+DB_NAME = os.environ.get("MONGO_DB", "choicepilot")
+ADMIN_EMAIL = os.environ.get("ADMIN_EMAIL", "admin@example.com")
+
+client = MongoClient(MONGO_URI)
+db = client[DB_NAME]
+
+async def send_daily_feedback_summary():
+    """Summarize feedback from the last 24 hours and email it."""
+    since = datetime.utcnow() - timedelta(days=1)
+    feedback = list(db.decision_feedback.find({"timestamp": {"$gte": since}}))
+    if not feedback:
+        return
+
+    helpful = sum(1 for f in feedback if f.get("helpful"))
+    not_helpful = len(feedback) - helpful
+    comments = [f.get("feedback_text") for f in feedback if f.get("feedback_text")]
+
+    summary_lines = [
+        f"Total feedback: {len(feedback)}",
+        f"Helpful: {helpful}",
+        f"Not Helpful: {not_helpful}",
+    ]
+    if comments:
+        summary_lines.append("Comments:\n" + "\n".join(f"- {c}" for c in comments[:10]))
+
+    email_service = EmailService()
+    await email_service._send_email(
+        ADMIN_EMAIL,
+        "Daily Feedback Summary",
+        "<pre>" + "\n".join(summary_lines) + "</pre>"
+    )

--- a/frontend/src/components/ConversationCard.jsx
+++ b/frontend/src/components/ConversationCard.jsx
@@ -3,7 +3,7 @@ import { Button } from '../components/ui/Button';
 import { Card, CardContent, CardHeader, CardTitle } from '../components/ui/Card';
 
 // Fixed ConversationCard Component
-const ConversationCard = ({ item, onFeedback, isAuthenticated, getConfidenceColor }) => {
+const ConversationCard = ({ item, index, onFeedback, isAuthenticated, getConfidenceColor }) => {
   const [showFeedback, setShowFeedback] = useState(false);
   const [feedbackReason, setFeedbackReason] = useState('');
   const [showFullReasoning, setShowFullReasoning] = useState(false);
@@ -11,7 +11,7 @@ const ConversationCard = ({ item, onFeedback, isAuthenticated, getConfidenceColo
   const handleFeedback = async (helpful, reason = '') => {
     try {
       if (onFeedback) {
-        onFeedback(helpful, reason);
+        onFeedback(helpful, reason, index);
       }
     } catch (error) {
       console.error('Feedback error:', error);

--- a/frontend/src/components/ToolsPanel.js
+++ b/frontend/src/components/ToolsPanel.js
@@ -7,14 +7,15 @@ import DecisionRandomizer from './DecisionRandomizer';
 const BACKEND_URL = process.env.REACT_APP_BACKEND_URL;
 const API = `${BACKEND_URL}/api`;
 
-const ToolsPanel = ({ 
-  isOpen, 
-  onClose, 
-  currentDecisionId, 
+const ToolsPanel = ({
+  isOpen,
+  onClose,
+  currentDecisionId,
   currentDecisionTitle,
   messages,
   subscriptionInfo,
-  advisorStyle 
+  advisorStyle,
+  favoriteVersion
 }) => {
   const [activeTab, setActiveTab] = useState('summary');
   const [decisions, setDecisions] = useState([]);
@@ -56,15 +57,9 @@ const ToolsPanel = ({
       setExportingPdf(true);
       setError('');
 
-      const response = await axios.post(
-        `${API}/decisions/${currentDecisionId}/export-pdf`,
-        {},
-        {
-          responseType: 'blob',
-          headers: {
-            'Accept': 'application/pdf'
-          }
-        }
+      const response = await axios.get(
+        `${API}/decision/${currentDecisionId}/export?format=pdf&version=${favoriteVersion}`,
+        { responseType: 'blob' }
       );
 
       // Create download link

--- a/frontend/src/components/VersionCompareModal.jsx
+++ b/frontend/src/components/VersionCompareModal.jsx
@@ -1,0 +1,71 @@
+import React, { useEffect, useState } from 'react';
+import axios from 'axios';
+
+const BACKEND_URL = process.env.REACT_APP_BACKEND_URL;
+const API = `${BACKEND_URL}/api`;
+
+const VersionCompareModal = ({ decisionId, onClose }) => {
+  const [versions, setVersions] = useState([]);
+  const [selected, setSelected] = useState([]);
+  const [results, setResults] = useState(null);
+  const [error, setError] = useState('');
+
+  useEffect(() => {
+    axios.get(`${API}/decision/${decisionId}/versions`).then(r => {
+      setVersions(r.data.versions || []);
+    });
+  }, [decisionId]);
+
+  const toggle = (v) => {
+    setSelected(prev => {
+      if (prev.includes(v)) return prev.filter(x => x !== v);
+      if (prev.length < 3) return [...prev, v];
+      return prev;
+    });
+  };
+
+  const compare = async () => {
+    if (selected.length < 2) return;
+    try {
+      const res = await axios.post(`${API}/decision/${decisionId}/compare`, { versions: selected });
+      setResults(res.data);
+      setError('');
+    } catch (e) {
+      setError('Compare failed');
+    }
+  };
+
+  if (results) {
+    return (
+      <div className="bg-white p-4 rounded shadow max-w-xl mx-auto">
+        <h3 className="font-semibold mb-2">Comparison</h3>
+        <pre className="text-xs whitespace-pre-wrap">{JSON.stringify(results, null, 2)}</pre>
+        <button onClick={() => setResults(null)} className="mt-2 text-sm underline">Back</button>
+      </div>
+    );
+  }
+
+  return (
+    <div className="bg-white p-4 rounded shadow max-w-sm mx-auto">
+      <h3 className="font-semibold mb-2">Select up to 3 versions</h3>
+      {versions.map(v => (
+        <label key={v.version} className="block text-sm">
+          <input
+            type="checkbox"
+            checked={selected.includes(v.version)}
+            onChange={() => toggle(v.version)}
+            className="mr-2"
+          />
+          Version {v.version}
+        </label>
+      ))}
+      {error && <p className="text-red-600 text-sm mt-2">{error}</p>}
+      <div className="mt-3 flex gap-2">
+        <button onClick={compare} className="px-3 py-1 bg-blue-600 text-white text-sm rounded">Compare</button>
+        <button onClick={onClose} className="px-3 py-1 text-sm">Close</button>
+      </div>
+    </div>
+  );
+};
+
+export default VersionCompareModal;


### PR DESCRIPTION
## Summary
- enable comparing multiple decision versions and mark favorites in backend
- allow exporting specific version and submitting card-indexed feedback
- add daily feedback summary helper
- show compare button and star control in UI
- wire up feedback index and add version compare modal

## Testing
- `python -m py_compile backend/server.py backend/feedback_summary.py`
- `npx eslint .` *(fails: ESLint couldn't find config)*

------
https://chatgpt.com/codex/tasks/task_e_68542a50d7a883328f26dc205dc5740a