### PR TITLE
Use env vars for PostHog config

### DIFF
--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,3 +1,5 @@
 # Example environment variables for the React app
 WDS_SOCKET_PORT=443
 REACT_APP_BACKEND_URL=http://localhost:8001
+REACT_APP_POSTHOG_KEY=your-posthog-key
+REACT_APP_POSTHOG_HOST=https://us.i.posthog.com

--- a/frontend/src/lib/posthog.js
+++ b/frontend/src/lib/posthog.js
@@ -2,8 +2,8 @@ import { createContext, useContext, useEffect } from 'react';
 import posthog from 'posthog-js';
 
 // PostHog configuration
-const POSTHOG_API_KEY = 'phc_Ocu3kFXMxUjFSmRlDH1Fj2QOK32GS5CU0bBbMwdlHn2';
-const POSTHOG_HOST = 'https://us.i.posthog.com';
+const POSTHOG_API_KEY = process.env.REACT_APP_POSTHOG_KEY;
+const POSTHOG_HOST = process.env.REACT_APP_POSTHOG_HOST;
 
 // Initialize PostHog
 if (typeof window !== 'undefined') {


### PR DESCRIPTION
## Summary
- read PostHog settings from `REACT_APP_POSTHOG_*` environment vars
- document these variables in the frontend `.env.example`

## Testing
- `pytest -q` *(fails: 25 errors during collection)*
- `yarn test` *(fails: package missing in lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_685520dd90bc8332901e4d3d1d996831