### PR TITLE
Ignore .env files by default

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,7 +30,9 @@ yarn-error.log*
 *.log
 
 # local env files
-# .env*.local
+*.env
+*.env.*
+!*.env.example
 *token.json*
 # vercel
 .vercel
@@ -39,7 +41,6 @@ yarn-error.log*
 *.tsbuildinfo
 next-env.d.ts
 *pyc*
-#*.env
 .ac
 agenthub/agents/youtube/db
 *credentials.json*


### PR DESCRIPTION
## Summary
- ignore generic `.env` patterns in `.gitignore`

## Testing
- `git check-ignore -v --no-index dummy.env`
- `git check-ignore -v --no-index .env.local`


------
https://chatgpt.com/codex/tasks/task_e_685520e461e88332b0bf78418f15b842