### PR TITLE
Update landing page examples

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -428,7 +428,7 @@ const LandingPage = ({ onStartDecision }) => {
                   
                   <div className="flex justify-between items-center">
                     <p className="text-xs text-muted-foreground">
-                      E.g., "Should I switch careers?" or "Which city should I move to?"
+                      E.g., "Should we expand to a European market?" or "Which CRM system best fits our needs?"
                     </p>
                     <Button
                       onClick={handleStartDecision}
@@ -2199,7 +2199,7 @@ const Dashboard = ({ onStartDecision }) => {
                 
                 <div className="flex justify-between items-center">
                   <p className="text-xs text-muted-foreground">
-                    E.g., "Should I switch careers?" or "Which city should I move to?"
+                    E.g., "Should we expand to a European market?" or "Which CRM system best fits our needs?"
                   </p>
                   <Button
                     onClick={handleStartDecision}
@@ -2409,19 +2409,19 @@ const SideChatModal = ({ isOpen, onClose, onStartNewDecision }) => {
   const [conversations, setConversations] = useState([
     {
       id: 1,
-      question: "Should I switch careers to data science?",
+      question: "Should we expand to the European market next year?",
       date: "2 days ago",
       confidence: 85
     },
     {
       id: 2,
-      question: "Is it worth buying a house in the current market?",
+      question: "Is investing in electric company vehicles worthwhile?",
       date: "1 week ago",
       confidence: 72
     },
     {
       id: 3,
-      question: "Should I adopt a dog or a cat?",
+      question: "Which CRM software best fits our growing startup?",
       date: "2 weeks ago",
       confidence: 91
     }

--- a/frontend/src/App.js.bak
+++ b/frontend/src/App.js.bak
@@ -428,7 +428,7 @@ const LandingPage = ({ onStartDecision }) => {
                   
                   <div className="flex justify-between items-center">
                     <p className="text-xs text-muted-foreground">
-                      E.g., "Should I switch careers?" or "Which city should I move to?"
+                      E.g., "Should we expand to a European market?" or "Which CRM system best fits our needs?"
                     </p>
                     <Button
                       onClick={handleStartDecision}

--- a/frontend/src/App.js.bak2
+++ b/frontend/src/App.js.bak2
@@ -428,7 +428,7 @@ const LandingPage = ({ onStartDecision }) => {
                   
                   <div className="flex justify-between items-center">
                     <p className="text-xs text-muted-foreground">
-                      E.g., "Should I switch careers?" or "Which city should I move to?"
+                      E.g., "Should we expand to a European market?" or "Which CRM system best fits our needs?"
                     </p>
                     <Button
                       onClick={handleStartDecision}

--- a/frontend/src/App.original.js
+++ b/frontend/src/App.original.js
@@ -429,7 +429,7 @@ const LandingPage = ({ onStartDecision }) => {
                   
                   <div className="flex justify-between items-center">
                     <p className="text-xs text-muted-foreground">
-                      E.g., "Should I switch careers?" or "Which city should I move to?"
+                      E.g., "Should we expand to a European market?" or "Which CRM system best fits our needs?"
                     </p>
                     <Button
                       onClick={handleStartDecision}


### PR DESCRIPTION
## Summary
- use concrete examples in the landing page guidance text
- update sample conversations with realistic business decisions

## Testing
- `pytest -q` *(fails: 25 errors during collection)*
- `yarn test --watchAll=false` in `frontend` *(fails: package not in lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_6855226f26e48332b5e3fecc6bd966e4