### PR TITLE
Refine modal theme

### DIFF
--- a/frontend/src/components/BillingDashboard.js
+++ b/frontend/src/components/BillingDashboard.js
@@ -128,7 +128,7 @@ const BillingDashboard = ({ user, subscriptionInfo, onClose }) => {
   if (loading) {
     return (
       <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50">
-        <div className="bg-white rounded-xl p-8 max-w-md w-full mx-4">
+        <div className="bg-card rounded-xl p-8 max-w-md w-full mx-4">
           <div className="text-center">
             <div className="animate-spin rounded-full h-12 w-12 gingee-border-coral border-b-2 mx-auto mb-4"></div>
             <p className="text-gray-600">Loading billing information...</p>
@@ -140,12 +140,12 @@ const BillingDashboard = ({ user, subscriptionInfo, onClose }) => {
 
   return (
     <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50 p-4">
-      <div className="bg-white rounded-xl max-w-6xl w-full max-h-[90vh] overflow-y-auto">
+      <div className="bg-card rounded-xl max-w-6xl w-full max-h-[90vh] overflow-y-auto">
         {/* Header */}
-        <div className="flex items-center justify-between p-6 border-b border-gray-200">
+        <div className="flex items-center justify-between p-6 border-b border-border">
           <div>
-            <h2 className="text-2xl font-bold text-gray-900">Billing & Subscription</h2>
-            <p className="text-gray-600">Manage your getgingee subscription and billing</p>
+            <h2 className="text-2xl font-bold text-foreground">Billing & Subscription</h2>
+            <p className="text-muted-foreground">Manage your getgingee subscription and billing</p>
           </div>
           <button
             onClick={onClose}

--- a/frontend/src/components/EmailVerification.js
+++ b/frontend/src/components/EmailVerification.js
@@ -77,7 +77,7 @@ const EmailVerification = ({ user, onVerificationComplete, onClose }) => {
 
   return (
     <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50">
-      <div className="bg-white rounded-xl p-8 max-w-md w-full mx-4">
+      <div className="bg-card rounded-xl p-8 max-w-md w-full mx-4">
         {/* Header */}
         <div className="text-center mb-6">
           <div className="w-16 h-16 bg-blue-100 rounded-full flex items-center justify-center mx-auto mb-4">
@@ -85,10 +85,10 @@ const EmailVerification = ({ user, onVerificationComplete, onClose }) => {
               <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M3 8l7.89 4.26a2 2 0 002.22 0L21 8M5 19h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z" />
             </svg>
           </div>
-          <h2 className="text-2xl font-bold text-gray-900 mb-2">Verify Your Email</h2>
-          <p className="text-gray-600">
+          <h2 className="text-2xl font-bold text-foreground mb-2">Verify Your Email</h2>
+          <p className="text-muted-foreground">
             We've sent a verification code to<br />
-            <span className="font-medium text-gray-900">{user.email}</span>
+            <span className="font-medium text-foreground">{user.email}</span>
           </p>
         </div>
 
@@ -157,9 +157,9 @@ const EmailVerification = ({ user, onVerificationComplete, onClose }) => {
         </form>
 
         {/* Resend Code */}
-        <div className="mt-6 pt-4 border-t border-gray-200">
+        <div className="mt-6 pt-4 border-t border-border">
           <div className="text-center">
-            <p className="text-sm text-gray-600 mb-3">
+            <p className="text-sm text-muted-foreground mb-3">
               Didn't receive the code?
             </p>
             <button

--- a/frontend/src/components/PaymentError.js
+++ b/frontend/src/components/PaymentError.js
@@ -26,7 +26,7 @@ const PaymentError = ({ onClose }) => {
 
   return (
     <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50">
-      <div className="bg-white rounded-xl p-8 max-w-md w-full mx-4 text-center">
+      <div className="bg-card rounded-xl p-8 max-w-md w-full mx-4 text-center">
         {/* Error Icon */}
         <div className="w-16 h-16 bg-red-100 rounded-full flex items-center justify-center mx-auto mb-6">
           <svg className="w-8 h-8 text-red-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -35,8 +35,8 @@ const PaymentError = ({ onClose }) => {
         </div>
 
         {/* Error Message */}
-        <h2 className="text-2xl font-bold text-gray-900 mb-2">Payment Failed</h2>
-        <p className="text-gray-600 mb-6">
+        <h2 className="text-2xl font-bold text-foreground mb-2">Payment Failed</h2>
+        <p className="text-muted-foreground mb-6">
           We encountered an issue processing your payment. Don't worry, no charges have been made to your account.
         </p>
 
@@ -90,16 +90,16 @@ const PaymentError = ({ onClose }) => {
           
           <button
             onClick={() => window.history.back()}
-            className="w-full bg-gray-100 text-gray-800 py-3 px-6 rounded-lg hover:bg-gray-200 transition-colors duration-200 font-medium"
+            className="w-full bg-muted text-foreground py-3 px-6 rounded-lg hover:bg-muted/80 transition-colors duration-200 font-medium"
           >
             Go Back
           </button>
         </div>
 
         {/* Support Section */}
-        <div className="mt-6 pt-4 border-t border-gray-200">
-          <h4 className="font-semibold text-gray-900 mb-2">Need Help?</h4>
-          <p className="text-sm text-gray-600 mb-3">
+        <div className="mt-6 pt-4 border-t border-border">
+          <h4 className="font-semibold text-foreground mb-2">Need Help?</h4>
+          <p className="text-sm text-muted-foreground mb-3">
             If you continue to experience issues, please contact our support team.
           </p>
           <div className="space-y-2">

--- a/frontend/src/components/PaymentSuccess.js
+++ b/frontend/src/components/PaymentSuccess.js
@@ -43,7 +43,7 @@ const PaymentSuccess = ({ onClose }) => {
 
   return (
     <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50">
-      <div className="bg-white rounded-xl p-8 max-w-md w-full mx-4 text-center">
+      <div className="bg-card rounded-xl p-8 max-w-md w-full mx-4 text-center">
         {/* Success Icon */}
         <div className="w-16 h-16 bg-green-100 rounded-full flex items-center justify-center mx-auto mb-6">
           <svg className="w-8 h-8 text-green-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -52,34 +52,34 @@ const PaymentSuccess = ({ onClose }) => {
         </div>
 
         {/* Success Message */}
-        <h2 className="text-2xl font-bold text-gray-900 mb-2">Payment Successful!</h2>
-        <p className="text-gray-600 mb-6">
+        <h2 className="text-2xl font-bold text-foreground mb-2">Payment Successful!</h2>
+        <p className="text-muted-foreground mb-6">
           Your payment has been processed successfully. Your account will be updated shortly.
         </p>
 
         {/* Payment Details */}
         {details.paymentId && (
-          <div className="bg-gray-50 rounded-lg p-4 mb-6 text-left">
-            <h3 className="font-semibold text-gray-900 mb-3">Payment Details</h3>
+          <div className="bg-muted/50 rounded-lg p-4 mb-6 text-left">
+            <h3 className="font-semibold text-foreground mb-3">Payment Details</h3>
             <div className="space-y-2 text-sm">
               {details.productName && (
                 <div className="flex justify-between">
-                  <span className="text-gray-600">Product:</span>
+                  <span className="text-muted-foreground">Product:</span>
                   <span className="font-medium">{details.productName}</span>
                 </div>
               )}
               {details.amount && (
                 <div className="flex justify-between">
-                  <span className="text-gray-600">Amount:</span>
+                  <span className="text-muted-foreground">Amount:</span>
                   <span className="font-medium">${details.amount}</span>
                 </div>
               )}
               <div className="flex justify-between">
-                <span className="text-gray-600">Payment ID:</span>
+                <span className="text-muted-foreground">Payment ID:</span>
                 <span className="font-mono text-xs">{details.paymentId}</span>
               </div>
               <div className="flex justify-between">
-                <span className="text-gray-600">Status:</span>
+                <span className="text-muted-foreground">Status:</span>
                 <span className="text-green-600 font-medium">✓ Completed</span>
               </div>
             </div>
@@ -106,14 +106,14 @@ const PaymentSuccess = ({ onClose }) => {
             Continue to ChoicePilot
           </button>
           
-          <p className="text-sm text-gray-500">
+          <p className="text-sm text-muted-foreground">
             Redirecting automatically in {countdown} seconds...
           </p>
         </div>
 
         {/* Support Link */}
-        <div className="mt-6 pt-4 border-t border-gray-200">
-          <p className="text-xs text-gray-500">
+        <div className="mt-6 pt-4 border-t border-border">
+          <p className="text-xs text-muted-foreground">
             Need help? Contact{' '}
             <a href="mailto:support@choicepilot.ai" className="text-blue-600 hover:text-blue-800">
               support@choicepilot.ai

--- a/frontend/src/components/ToolsPanel.js
+++ b/frontend/src/components/ToolsPanel.js
@@ -151,7 +151,7 @@ const ToolsPanel = ({
   if (activeTab === 'compare') {
     return (
       <div className="fixed inset-0 bg-black bg-opacity-50 z-50 flex items-center justify-center p-4">
-        <div className="bg-white rounded-xl max-w-7xl w-full max-h-[90vh] overflow-y-auto">
+        <div className="bg-card rounded-xl max-w-7xl w-full max-h-[90vh] overflow-y-auto">
           <DecisionComparison 
             decisions={decisions} 
             onClose={() => setActiveTab('summary')}
@@ -164,7 +164,7 @@ const ToolsPanel = ({
   if (activeTab === 'share') {
     return (
       <div className="fixed inset-0 bg-black bg-opacity-50 z-50 flex items-center justify-center p-4">
-        <div className="bg-white rounded-xl max-w-3xl w-full max-h-[90vh] overflow-y-auto">
+        <div className="bg-card rounded-xl max-w-3xl w-full max-h-[90vh] overflow-y-auto">
           <DecisionSharing 
             decisionId={currentDecisionId}
             decisionTitle={currentDecisionTitle}
@@ -178,7 +178,7 @@ const ToolsPanel = ({
   if (activeTab === 'randomizer') {
     return (
       <div className="fixed inset-0 bg-black bg-opacity-50 z-50 flex items-center justify-center p-4">
-        <div className="bg-white rounded-xl max-w-5xl w-full max-h-[90vh] overflow-y-auto">
+        <div className="bg-card rounded-xl max-w-5xl w-full max-h-[90vh] overflow-y-auto">
           <DecisionRandomizer onClose={() => setActiveTab('summary')} />
         </div>
       </div>
@@ -194,10 +194,10 @@ const ToolsPanel = ({
       ></div>
 
       {/* Panel */}
-      <div className="fixed right-0 top-0 h-full w-96 bg-white shadow-2xl z-50 flex flex-col">
+      <div className="fixed right-0 top-0 h-full w-96 bg-card shadow-2xl z-50 flex flex-col">
         {/* Header */}
-        <div className="flex items-center justify-between p-4 border-b border-gray-200">
-          <h2 className="text-lg font-semibold text-gray-900">Decision Tools</h2>
+        <div className="flex items-center justify-between p-4 border-b border-border">
+          <h2 className="text-lg font-semibold text-foreground">Decision Tools</h2>
           <button
             onClick={onClose}
             className="text-gray-500 hover:text-gray-700 text-xl font-bold"
@@ -213,7 +213,7 @@ const ToolsPanel = ({
         )}
 
         {/* Tabs */}
-        <div className="flex flex-wrap border-b border-gray-200 p-2 gap-1">
+        <div className="flex flex-wrap border-b border-border p-2 gap-1">
           {tabs.map(tab => (
             <button
               key={tab.id}
@@ -243,7 +243,7 @@ const ToolsPanel = ({
 
               {currentDecisionId && (
                 <div className="space-y-3">
-                  <div className="border-t border-gray-200 pt-4">
+                  <div className="border-t border-border pt-4">
                     <h4 className="font-medium text-gray-900 mb-2">Export Options</h4>
                     
                     <button
@@ -267,7 +267,7 @@ const ToolsPanel = ({
                     )}
                   </div>
 
-                  <div className="border-t border-gray-200 pt-4">
+                  <div className="border-t border-border pt-4">
                     <h4 className="font-medium text-gray-900 mb-2">Quick Actions</h4>
                     <div className="space-y-2">
                       <button

--- a/frontend/src/components/ui/Modal.jsx
+++ b/frontend/src/components/ui/Modal.jsx
@@ -5,7 +5,7 @@ export const Modal = ({ isOpen, onClose, className, children }) => {
   
   return (
     <div className="fixed inset-0 bg-black/50 flex items-center justify-center p-4 z-50">
-      <div className={`bg-white rounded-lg shadow-xl max-w-md w-full ${className}`}>
+      <div className={`bg-card rounded-lg shadow-xl max-w-md w-full ${className}`}>
         {children}
       </div>
     </div>

--- a/frontend/src/components/ui/SideModal.jsx
+++ b/frontend/src/components/ui/SideModal.jsx
@@ -6,7 +6,7 @@ export const SideModal = ({ isOpen, onClose, children }) => {
   return (
     <div className="fixed inset-0 z-50 flex">
       <div className="flex-1" onClick={onClose} />
-      <div className="w-96 bg-white border-l shadow-xl">
+      <div className="w-96 bg-card border-l border-border shadow-xl">
         {children}
       </div>
     </div>


### PR DESCRIPTION
## Summary
- update modal and side modal to use theme card backgrounds
- apply foreground colors in Payment* modals
- tweak billing dashboard and tools panel colors
- adjust email verification modal styles

## Testing
- `pytest -q` *(fails: Tunnel connection failed)*

------
https://chatgpt.com/codex/tasks/task_e_68552270477483329b7deb28ef8c1cdd