### PR TITLE
Add adjustment wizard with advisor selection

### DIFF
--- a/backend/ai_orchestrator.py
+++ b/backend/ai_orchestrator.py
@@ -247,7 +247,9 @@ Make questions specific to their situation and include practical nudges."""
         followup_answers: List[str],
         decision_type: DecisionType,
         user_profile: Dict = None,
-        enable_personalization: bool = False
+        enable_personalization: bool = False,
+        advisor_style: str = "realist",
+        adjustment_context: str = None,
     ) -> DecisionRecommendation:
         """
         Synthesize final decision using multi-framework approach
@@ -265,9 +267,15 @@ Decision Type: {decision_type.value}
 User Responses:
 {chr(10).join([f"{i+1}. {answer}" for i, answer in enumerate(followup_answers)])}
 """
-        
+
         if enable_personalization and user_profile:
             context += f"\nUser Profile Context: {user_profile.get('preferences', 'No specific preferences')}"
+
+        if adjustment_context:
+            context += f"\nAdjustment Request: {adjustment_context}"
+
+        if advisor_style:
+            context += f"\nAdvisor Persona: {advisor_style}"
 
         # Generate decision using appropriate models
         if len(models) == 1:

--- a/backend/ai_orchestrator_v2.py
+++ b/backend/ai_orchestrator_v2.py
@@ -435,7 +435,9 @@ Make questions specific to their situation and include practical nudges."""
         followup_answers: List[str],
         decision_type: DecisionType,
         user_profile: Dict = None,
-        enable_personalization: bool = False
+        enable_personalization: bool = False,
+        advisor_style: str = "realist",
+        adjustment_context: str = None,
     ) -> DecisionRecommendation:
         """
         Synthesize final decision using multi-framework approach
@@ -453,9 +455,15 @@ Decision Type: {decision_type.value}
 User Responses:
 {chr(10).join([f"{i+1}. {answer}" for i, answer in enumerate(followup_answers)])}
 """
-        
+
         if enable_personalization and user_profile:
             context += f"\nUser Profile Context: {user_profile.get('preferences', 'No specific preferences')}"
+
+        if adjustment_context:
+            context += f"\nAdjustment Request: {adjustment_context}"
+
+        if advisor_style:
+            context += f"\nAdvisor Persona: {advisor_style}"
 
         # Generate decision using appropriate models
         if len(models) == 1:

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -9,6 +9,7 @@ import { Modal, ModalContent, ModalHeader, ModalTitle } from './components/ui/Mo
 import { SideModal } from './components/ui/SideModal';
 import { Switch } from './components/ui/Switch';
 import { Progress } from './components/ui/Progress';
+import AdjustWizard from './components/AdjustWizard';
 
 // PostHog Analytics
 import { usePostHog, PostHogProvider } from './lib/posthog';
@@ -1516,157 +1517,43 @@ const DecisionFlow = ({ initialQuestion, onComplete, onSaveAndContinue }) => {
             </div>
           </div>
         )}
-        
-        {/* Adjust Decision Modal */}
+
         {showAdjustModal && (
-          <div className="fixed inset-0 bg-black/50 backdrop-blur-sm z-50 flex items-center justify-center p-4">
-            <div className="bg-white dark:bg-slate-900 rounded-lg shadow-xl max-w-md w-full">
-              <div className="p-6">
-                <div className="flex items-center justify-between mb-4">
-                  <h3 className="text-lg font-semibold text-foreground">🔧 Adjust Decision</h3>
-                  <button
-                    onClick={() => setShowAdjustModal(false)}
-                    className="text-muted-foreground hover:text-foreground"
-                  >
-                    ✕
-                  </button>
-                </div>
-                
-                <div className="space-y-4">
-                  <p className="text-sm text-muted-foreground">
-                    What would you like to change?
-                  </p>
-                  
-                  <div className="space-y-3">
-                    <label className="flex items-center gap-3 p-3 border border-border rounded-lg cursor-pointer hover:bg-muted/50">
-                      <input
-                        type="radio"
-                        name="adjustmentReason"
-                        value="edit_answers"
-                        onChange={(e) => setAdjustmentReason(e.target.value)}
-                        className="w-4 h-4 text-primary"
-                      />
-                      <div>
-                        <div className="font-medium text-foreground">Edit previous answers</div>
-                        <div className="text-xs text-muted-foreground">Modify your responses to follow-up questions</div>
-                      </div>
-                    </label>
-                    
-                    <label className="flex items-center gap-3 p-3 border border-border rounded-lg cursor-pointer hover:bg-muted/50">
-                      <input
-                        type="radio"
-                        name="adjustmentReason"
-                        value="new_persona"
-                        onChange={(e) => setAdjustmentReason(e.target.value)}
-                        className="w-4 h-4 text-primary"
-                      />
-                      <div>
-                        <div className="font-medium text-foreground">Ask fresh questions with new advisor</div>
-                        <div className="text-xs text-muted-foreground">Get different perspective from another advisor</div>
-                      </div>
-                    </label>
-                    
-                    <label className="flex items-center gap-3 p-3 border border-border rounded-lg cursor-pointer hover:bg-muted/50">
-                      <input
-                        type="radio"
-                        name="adjustmentReason"
-                        value="change_type"
-                        onChange={(e) => setAdjustmentReason(e.target.value)}
-                        className="w-4 h-4 text-primary"
-                      />
-                      <div>
-                        <div className="font-medium text-foreground">Change decision approach</div>
-                        <div className="text-xs text-muted-foreground">Switch between structured/intuitive analysis</div>
-                      </div>
-                    </label>
-                  </div>
-                  
-                  <div className="flex justify-end gap-3 pt-4">
-                    <button
-                      onClick={() => setShowAdjustModal(false)}
-                      className="px-4 py-2 text-sm font-medium text-muted-foreground border border-border rounded-lg hover:bg-muted/50"
-                    >
-                      Cancel
-                    </button>
-                    <button
-                      onClick={async () => {
-                        if (!adjustmentReason) return;
-                        
-                        try {
-                          let newRecommendation;
-                          
-                          switch (adjustmentReason) {
-                            case 'edit_answers':
-                              // Start new flow allowing user to edit previous answers
-                              setCurrentStep('edit_flow');
-                              setShowAdjustModal(false);
-                              // You would implement edit flow here
-                              alert('Edit flow would start here - allowing you to modify previous answers and regenerate recommendation.');
-                              break;
-                              
-                            case 'new_persona':
-                              // Get recommendation with different advisor persona
-                              const response = await axios.post(`${API}/api/decision/advanced`, {
-                                message: initialQuestion,
-                                step: 'recommendation',
-                                decision_id: decisionId,
-                                force_different_persona: true
-                              });
-                              
-                              if (response.data.recommendation) {
-                                setRecommendation(response.data.recommendation);
-                                const newRecCard = {
-                                  type: 'ai_recommendation',
-                                  content: response.data.recommendation,
-                                  timestamp: new Date(),
-                                  id: Date.now()
-                                };
-                                setConversationHistory(prev => [...prev, newRecCard]);
-                              }
-                              break;
-                              
-                            case 'change_type':
-                              // Switch analysis approach
-                              const approachResponse = await axios.post(`${API}/api/decision/advanced`, {
-                                message: initialQuestion,
-                                step: 'recommendation', 
-                                decision_id: decisionId,
-                                force_different_approach: true
-                              });
-                              
-                              if (approachResponse.data.recommendation) {
-                                setRecommendation(approachResponse.data.recommendation);
-                                const newRecCard = {
-                                  type: 'ai_recommendation',
-                                  content: approachResponse.data.recommendation,
-                                  timestamp: new Date(),
-                                  id: Date.now()
-                                };
-                                setConversationHistory(prev => [...prev, newRecCard]);
-                              }
-                              break;
-                          }
-                          
-                          setShowAdjustModal(false);
-                          setAdjustmentReason('');
-                          
-                        } catch (error) {
-                          console.error('Error adjusting decision:', error);
-                          alert('Failed to adjust decision. Please try again.');
-                        }
-                      }}
-                      className="px-4 py-2 text-sm font-medium bg-primary text-primary-foreground rounded-lg hover:bg-primary/90 disabled:opacity-50"
-                      disabled={!adjustmentReason}
-                    >
-                      🔄 Apply Changes
-                    </button>
-                  </div>
-                </div>
-              </div>
-            </div>
-          </div>
+          <AdjustWizard
+            isOpen={showAdjustModal}
+            onClose={() => setShowAdjustModal(false)}
+            onApply={async ({ adjustmentType, advisor, reuseQuestions }) => {
+              try {
+                if (adjustmentType === 'edit_answers') {
+                  setCurrentStep('edit_flow');
+                  return;
+                }
+
+                const resp = await axios.post(`${API}/api/decision/advanced`, {
+                  step: 'adjust',
+                  decision_id: decisionId,
+                  adjustment_context: initialQuestion,
+                  adjustment_type: adjustmentType,
+                  new_persona: advisor,
+                  reuse_questions: reuseQuestions
+                });
+
+                if (resp.data.followup_questions && !resp.data.is_complete) {
+                  setFollowupQuestions(resp.data.followup_questions);
+                  setCurrentStep('followup');
+                }
+
+                if (resp.data.recommendation) {
+                  setRecommendation(resp.data.recommendation);
+                  setConversationHistory(prev => [...prev, { type: 'ai_recommendation', content: resp.data.recommendation, timestamp: new Date() }]);
+                }
+              } catch (e) {
+                console.error('Adjust error', e);
+              }
+            }}
+          />
         )}
-        
+
         {/* Upgrade to Pro Modal */}
         {showUpgradeModal && (
           <div className="fixed inset-0 bg-black/50 backdrop-blur-sm z-50 flex items-center justify-center p-4">

--- a/frontend/src/components/AdjustWizard.jsx
+++ b/frontend/src/components/AdjustWizard.jsx
@@ -1,0 +1,113 @@
+import React, { useState, useEffect } from 'react';
+import { Modal } from './ui/Modal';
+
+const advisorOptions = [
+  { value: 'realist', label: 'Realist' },
+  { value: 'visionary', label: 'Visionary' },
+  { value: 'creative', label: 'Creative' },
+  { value: 'pragmatist', label: 'Pragmatist' },
+  { value: 'supportive', label: 'Supportive' },
+  { value: 'optimistic', label: 'Optimistic' },
+  { value: 'skeptical', label: 'Skeptical' },
+  { value: 'analytical', label: 'Analytical' }
+];
+
+const AdjustWizard = ({ isOpen, onClose, onApply }) => {
+  const [step, setStep] = useState(1);
+  const [adjustmentType, setAdjustmentType] = useState('');
+  const [advisor, setAdvisor] = useState('realist');
+  const [reuseQuestions, setReuseQuestions] = useState(true);
+
+  useEffect(() => {
+    if (!isOpen) {
+      setStep(1);
+      setAdjustmentType('');
+      setAdvisor('realist');
+      setReuseQuestions(true);
+    }
+  }, [isOpen]);
+
+  const nextStep = () => {
+    if (step === 1) {
+      if (adjustmentType === 'new_persona') {
+        setStep(2);
+      } else {
+        setStep(3);
+      }
+    } else if (step === 2) {
+      setStep(3);
+    }
+  };
+
+  const prevStep = () => {
+    setStep(step - 1);
+  };
+
+  const handleApply = () => {
+    onApply({ adjustmentType, advisor, reuseQuestions });
+    onClose();
+  };
+
+  return (
+    <Modal isOpen={isOpen} onClose={onClose} className="p-6">
+      {step === 1 && (
+        <div className="space-y-4">
+          <h3 className="text-lg font-semibold text-foreground">What would you like to change?</h3>
+          <div className="space-y-3">
+            <label className="flex items-center gap-3 p-3 border border-border rounded-lg cursor-pointer hover:bg-muted/50">
+              <input type="radio" name="adjustType" value="edit_answers" onChange={e => setAdjustmentType(e.target.value)} className="w-4 h-4" />
+              <span>Edit previous answers</span>
+            </label>
+            <label className="flex items-center gap-3 p-3 border border-border rounded-lg cursor-pointer hover:bg-muted/50">
+              <input type="radio" name="adjustType" value="new_persona" onChange={e => setAdjustmentType(e.target.value)} className="w-4 h-4" />
+              <span>Ask fresh questions with new advisor</span>
+            </label>
+            <label className="flex items-center gap-3 p-3 border border-border rounded-lg cursor-pointer hover:bg-muted/50">
+              <input type="radio" name="adjustType" value="change_type" onChange={e => setAdjustmentType(e.target.value)} className="w-4 h-4" />
+              <span>Change decision approach</span>
+            </label>
+          </div>
+          <div className="flex justify-end gap-2 pt-4">
+            <button onClick={onClose} className="px-3 py-1 border rounded">Cancel</button>
+            <button onClick={nextStep} disabled={!adjustmentType} className="px-3 py-1 bg-primary text-primary-foreground rounded">Next</button>
+          </div>
+        </div>
+      )}
+
+      {step === 2 && (
+        <div className="space-y-4">
+          <h3 className="text-lg font-semibold text-foreground">Choose an advisor</h3>
+          <select value={advisor} onChange={e => setAdvisor(e.target.value)} className="w-full border p-2 rounded">
+            {advisorOptions.map(opt => (
+              <option key={opt.value} value={opt.value}>{opt.label}</option>
+            ))}
+          </select>
+          <div className="flex justify-between pt-4">
+            <button onClick={prevStep} className="px-3 py-1 border rounded">Back</button>
+            <button onClick={nextStep} className="px-3 py-1 bg-primary text-primary-foreground rounded">Next</button>
+          </div>
+        </div>
+      )}
+
+      {step === 3 && (
+        <div className="space-y-4">
+          <h3 className="text-lg font-semibold text-foreground">Follow-up questions</h3>
+          <label className="flex items-center gap-3">
+            <input type="radio" name="reuse" value="true" checked={reuseQuestions} onChange={() => setReuseQuestions(true)} className="w-4 h-4" />
+            <span>Reuse existing questions</span>
+          </label>
+          <label className="flex items-center gap-3">
+            <input type="radio" name="reuse" value="false" checked={!reuseQuestions} onChange={() => setReuseQuestions(false)} className="w-4 h-4" />
+            <span>Generate new questions</span>
+          </label>
+          <div className="flex justify-between pt-4">
+            {adjustmentType === 'new_persona' && (<button onClick={prevStep} className="px-3 py-1 border rounded">Back</button>)}
+            <button onClick={handleApply} className="px-3 py-1 bg-primary text-primary-foreground rounded">Apply Changes</button>
+          </div>
+        </div>
+      )}
+    </Modal>
+  );
+};
+
+export default AdjustWizard;


### PR DESCRIPTION
## Summary
- add `AdjustWizard` React component to guide adjustments
- integrate wizard into main app
- extend backend models for adjustment inputs
- update advanced adjust logic to allow selecting a new persona and regenerating questions
- pass persona and adjustment context through AI orchestrator

## Testing
- `pytest -q` *(fails: 25 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68552273130083328ef707761df89dd8