### PR TITLE
Add usage tracking and upgrade prompts

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -148,6 +148,12 @@ const App = () => {
     return () => delete window.showAuthModal;
   }, []);
 
+  // Make upgrade modal accessible globally
+  useEffect(() => {
+    window.showUpgradeModal = () => setShowUpgradeModal(true);
+    return () => delete window.showUpgradeModal;
+  }, []);
+
   // Close user menu when clicking outside
   useEffect(() => {
     const handleClickOutside = (event) => {
@@ -720,6 +726,12 @@ const DecisionFlow = ({ initialQuestion, onComplete, onSaveAndContinue }) => {
       
     } catch (error) {
       console.error('Decision error:', error);
+      if (error.response && (error.response.status === 403 || error.response.status === 402)) {
+        if (window.showUpgradeModal) window.showUpgradeModal();
+        setLoading(false);
+        setProcessingStep('');
+        return;
+      }
       setError('We\'re having trouble analyzing your decision. Using our fallback system...');
       // Fallback to local questions on API error
       await generateFallbackFollowups(question);
@@ -926,6 +938,13 @@ const DecisionFlow = ({ initialQuestion, onComplete, onSaveAndContinue }) => {
       
     } catch (error) {
       console.error('Followup error:', error);
+      if (error.response && (error.response.status === 403 || error.response.status === 402)) {
+        if (window.showUpgradeModal) window.showUpgradeModal();
+        setLoading(false);
+        setProcessingStep('');
+        setQuestionSubmitted(false);
+        return;
+      }
       console.log('Backend response error:', error.response?.data);
       
       // Better fallback - try to generate recommendation instead of cycling through old questions
@@ -998,6 +1017,12 @@ const DecisionFlow = ({ initialQuestion, onComplete, onSaveAndContinue }) => {
       
     } catch (error) {
       console.error('Recommendation error:', error);
+      if (error.response && (error.response.status === 403 || error.response.status === 402)) {
+        if (window.showUpgradeModal) window.showUpgradeModal();
+        setLoading(false);
+        setProcessingStep('');
+        return;
+      }
       // Fallback to intelligent local recommendation
       const allAnswers = conversationHistory
         .filter(item => item.type === 'user_answer')

--- a/frontend/src/components/DecisionComparison.js
+++ b/frontend/src/components/DecisionComparison.js
@@ -30,12 +30,16 @@ const DecisionComparison = ({ decisions, onClose }) => {
     try {
       setLoading(true);
       setError('');
-      
+
       const response = await axios.post(`${API}/decisions/compare`, selectedDecisions);
       setComparisonData(response.data);
     } catch (error) {
       console.error('Error comparing decisions:', error);
-      setError(error.response?.data?.detail || 'Failed to compare decisions');
+      if (error.response && (error.response.status === 403 || error.response.status === 402)) {
+        if (window.showUpgradeModal) window.showUpgradeModal();
+      } else {
+        setError(error.response?.data?.detail || 'Failed to compare decisions');
+      }
     } finally {
       setLoading(false);
     }


### PR DESCRIPTION
## Summary
- track monthly sessions, comparisons and debates on the backend
- return upgrade error when limits exceeded
- show upgrade modal when API indicates a limit hit
- expose global `showUpgradeModal` for other components
- placeholder `/api/debate` endpoint

## Testing
- `pytest` *(fails: ProxyError)*
- `yarn test` *(fails: dependency errors)*

------
https://chatgpt.com/codex/tasks/task_e_68552276ba408332af8838d9e9ee1d59