### PR TITLE
Add loading overlay to modals

### DIFF
--- a/frontend/src/components/ui/GDPRComponents.js
+++ b/frontend/src/components/ui/GDPRComponents.js
@@ -15,7 +15,7 @@ const ConfirmationModal = ({
   loading = false 
 }) => {
   return (
-    <Modal isOpen={isOpen} onClose={onClose} className="max-w-md">
+    <Modal isOpen={isOpen} onClose={onClose} className="max-w-md" loading={loading}>
       <ModalHeader>
         <div className="flex items-center gap-3">
           <div className="p-2 bg-secondary-coral/10 rounded-full">
@@ -127,7 +127,7 @@ const PrivacySettingsModal = ({ isOpen, onClose, user }) => {
 
   return (
     <>
-      <Modal isOpen={isOpen} onClose={onClose} className="max-w-2xl">
+      <Modal isOpen={isOpen} onClose={onClose} className="max-w-2xl" loading={loading}>
         <ModalHeader>
           <ModalTitle>Privacy & Data Settings</ModalTitle>
           <p className="text-muted-foreground mt-2">

--- a/frontend/src/components/ui/Modal.js
+++ b/frontend/src/components/ui/Modal.js
@@ -2,19 +2,19 @@ import React from "react";
 import { cn } from "../../lib/utils";
 import { X } from "lucide-react";
 
-const Modal = ({ isOpen, onClose, children, className }) => {
+const Modal = ({ isOpen, onClose, children, className, loading = false }) => {
   if (!isOpen) return null;
 
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center">
       {/* Backdrop */}
-      <div 
-        className="fixed inset-0 bg-black/50 backdrop-blur-sm" 
+      <div
+        className="fixed inset-0 bg-black/50 backdrop-blur-sm"
         onClick={onClose}
       />
-      
+
       {/* Modal Content */}
-      <div 
+      <div
         className={cn(
           "relative bg-card border border-border rounded-lg shadow-lg max-w-md w-full mx-4 max-h-[90vh] overflow-auto",
           className
@@ -27,7 +27,13 @@ const Modal = ({ isOpen, onClose, children, className }) => {
         >
           <X className="h-4 w-4" />
         </button>
-        
+
+        {loading && (
+          <div className="absolute inset-0 bg-background/70 flex items-center justify-center rounded-lg">
+            <div className="w-6 h-6 border-2 border-muted border-t-transparent rounded-full animate-spin" />
+          </div>
+        )}
+
         {children}
       </div>
     </div>

--- a/frontend/src/components/ui/Modal.jsx
+++ b/frontend/src/components/ui/Modal.jsx
@@ -1,11 +1,16 @@
 import React from 'react';
 
-export const Modal = ({ isOpen, onClose, className, children }) => {
+export const Modal = ({ isOpen, onClose, className, children, loading = false }) => {
   if (!isOpen) return null;
   
   return (
     <div className="fixed inset-0 bg-black/50 flex items-center justify-center p-4 z-50">
-      <div className={`bg-white rounded-lg shadow-xl max-w-md w-full ${className}`}>
+      <div className={`relative bg-white rounded-lg shadow-xl max-w-md w-full ${className}`}>
+        {loading && (
+          <div className="absolute inset-0 bg-white/70 flex items-center justify-center rounded-lg">
+            <div className="w-6 h-6 border-2 border-gray-300 border-t-transparent rounded-full animate-spin"></div>
+          </div>
+        )}
         {children}
       </div>
     </div>


### PR DESCRIPTION
## Summary
- show a spinner overlay in `Modal` components when loading
- pass loading state down in GDPR modals

## Testing
- `CI=true yarn test --watchAll=false` *(fails: This package doesn't seem to be present in your lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_68552278a6448332b998f0a6e80967ab