### PR TITLE
Add version history drawer

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -7,6 +7,7 @@ import { Input } from './components/ui/Input';
 import { Card, CardContent, CardHeader, CardTitle, CardDescription } from './components/ui/Card';
 import { Modal, ModalContent, ModalHeader, ModalTitle } from './components/ui/Modal';
 import { SideModal } from './components/ui/SideModal';
+import DecisionVersionDrawer from './components/DecisionVersionDrawer';
 import { Switch } from './components/ui/Switch';
 import { Progress } from './components/ui/Progress';
 
@@ -369,6 +370,12 @@ const AppContent = ({
           setCurrentView('flow');
         }}
       />
+      <DecisionVersionDrawer
+        isOpen={showVersionDrawer}
+        onClose={() => setShowVersionDrawer(false)}
+        decisionId={decisionId}
+        onSelect={handleVersionSelect}
+      />
     </>
   );
 };
@@ -559,6 +566,7 @@ const DecisionFlow = ({ initialQuestion, onComplete, onSaveAndContinue }) => {
   const [showExportModal, setShowExportModal] = useState(false);
   const [showShareModal, setShowShareModal] = useState(false);
   const [showVersionCarousel, setShowVersionCarousel] = useState(false);
+  const [showVersionDrawer, setShowVersionDrawer] = useState(false);
   const [showAIDebateModal, setShowAIDebateModal] = useState(false);
   const [showFeedback, setShowFeedback] = useState(false);
   const [feedbackSubmitted, setFeedbackSubmitted] = useState(false);
@@ -1101,6 +1109,18 @@ const DecisionFlow = ({ initialQuestion, onComplete, onSaveAndContinue }) => {
     }
   };
 
+  const handleVersionSelect = (version) => {
+    if (!version || !version.recommendation) return;
+    setDecisionVersions(prev => {
+      const updated = [...prev];
+      updated[version.version - 1] = version.recommendation;
+      return updated;
+    });
+    setRecommendation(version.recommendation);
+    setCurrentVersion(version.version - 1);
+    setActiveSummaryIndex(version.version - 1);
+  };
+
   const currentQuestion = followupQuestions[currentFollowupIndex];
 
   // Utility function for confidence color coding
@@ -1277,6 +1297,15 @@ const DecisionFlow = ({ initialQuestion, onComplete, onSaveAndContinue }) => {
                   className="flex items-center gap-2 px-6 py-3 text-base font-semibold bg-blue-50 hover:bg-blue-100 border-blue-200 hover:border-blue-300 text-blue-700 transition-all duration-200"
                 >
                   📊 Compare
+                </Button>
+              )}
+              {decisionVersions.length > 0 && (
+                <Button
+                  variant="outline"
+                  onClick={() => setShowVersionDrawer(true)}
+                  className="flex items-center gap-2 px-6 py-3 text-base font-semibold bg-muted hover:bg-muted/50 border-border transition-all duration-200"
+                >
+                  🕑 Versions
                 </Button>
               )}
             </div>

--- a/frontend/src/components/DecisionVersionDrawer.js
+++ b/frontend/src/components/DecisionVersionDrawer.js
@@ -1,0 +1,70 @@
+import React, { useState, useEffect } from 'react';
+import axios from 'axios';
+import { SideModal, SideModalHeader, SideModalContent } from './ui/SideModal';
+
+const BACKEND_URL = process.env.REACT_APP_BACKEND_URL;
+const API = `${BACKEND_URL}/api`;
+
+const formatDate = (dateString) => {
+  const d = new Date(dateString);
+  return d.toLocaleString();
+};
+
+const DecisionVersionDrawer = ({ isOpen, onClose, decisionId, onSelect }) => {
+  const [versions, setVersions] = useState([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState('');
+
+  useEffect(() => {
+    const fetchVersions = async () => {
+      if (!decisionId || !isOpen) return;
+      try {
+        setLoading(true);
+        const res = await axios.get(`${API}/decision/${decisionId}/versions`);
+        setVersions(res.data.versions || []);
+      } catch (err) {
+        console.error('Failed to load versions', err);
+        setError('Failed to load versions');
+      } finally {
+        setLoading(false);
+      }
+    };
+    fetchVersions();
+  }, [decisionId, isOpen]);
+
+  return (
+    <SideModal isOpen={isOpen} onClose={onClose} className="w-80">
+      <SideModalHeader onClose={onClose}>
+        <h3 className="font-semibold text-foreground">Versions</h3>
+      </SideModalHeader>
+      <SideModalContent>
+        {loading && <p className="text-sm">Loading...</p>}
+        {error && <p className="text-sm text-red-600">{error}</p>}
+        {!loading && versions.length === 0 && (
+          <p className="text-sm text-muted-foreground">No versions found</p>
+        )}
+        <div className="space-y-3">
+          {versions.map((v) => (
+            <div
+              key={v.version}
+              className="p-3 border border-border rounded-lg hover:bg-muted/50 cursor-pointer"
+              onClick={() => {
+                onSelect && onSelect(v);
+                onClose();
+              }}
+            >
+              <div className="flex items-center justify-between">
+                <span className="font-medium">v{v.version}</span>
+                <span className="text-xs text-muted-foreground">
+                  {formatDate(v.created_at)}
+                </span>
+              </div>
+            </div>
+          ))}
+        </div>
+      </SideModalContent>
+    </SideModal>
+  );
+};
+
+export default DecisionVersionDrawer;


### PR DESCRIPTION
## Summary
- add `DecisionVersionDrawer` component to fetch and display previous versions
- hook drawer into main app with ability to select versions
- include Versions button in recommendation action bar

## Testing
- `pytest` *(fails: 25 errors during collection)*
- `yarn test` *(fails: package not present in lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_6855227cfdc083328009028f1a035267