### PR TITLE
Add email verification links

### DIFF
--- a/backend/account_management.py
+++ b/backend/account_management.py
@@ -13,19 +13,24 @@ import uuid
 
 logger = logging.getLogger(__name__)
 
+
 class EmailVerificationRequest(BaseModel):
     email: EmailStr
+
 
 class EmailVerificationConfirm(BaseModel):
     email: EmailStr
     verification_code: str
 
+
 class AccountDeletionRequest(BaseModel):
     password: str
     confirmation: str = "DELETE_MY_ACCOUNT"
 
+
 class DataExportRequest(BaseModel):
     export_format: str = "json"  # json, csv
+
 
 class PrivacySettings(BaseModel):
     data_sharing: bool = False
@@ -33,113 +38,114 @@ class PrivacySettings(BaseModel):
     marketing_emails: bool = False
     security_notifications: bool = True
 
+
 class AccountSecurityService:
     """Service for managing account security features"""
-    
+
     def __init__(self, db):
         self.db = db
         self.email_service = EmailService()
-    
+
     async def send_email_verification(self, user_email: str) -> dict:
-        """Send email verification code"""
+        """Send email verification token and code"""
         try:
             # Generate verification code
             verification_code = secrets.token_hex(3).upper()  # 6-char hex code
-            
+            verification_token = secrets.token_urlsafe(32)
+
             # Store verification code with expiry
             verification_doc = {
                 "email": user_email,
                 "code": verification_code,
+                "token": verification_token,
                 "created_at": datetime.utcnow(),
                 "expires_at": datetime.utcnow() + timedelta(hours=24),
                 "attempts": 0,
-                "is_used": False
+                "is_used": False,
             }
-            
+
             await self.db.email_verifications.insert_one(verification_doc)
-            
+
+            verification_link = f"{os.environ.get('FRONTEND_URL')}/verify-email?token={verification_token}&email={user_email}"
+
             # Send email
-            await self.email_service.send_verification_email(user_email, verification_code)
-            
-            return {
-                "message": "Verification email sent",
-                "expires_in": "24 hours"
-            }
-            
+            await self.email_service.send_verification_email(
+                user_email, verification_link, verification_code
+            )
+
+            return {"message": "Verification email sent", "expires_in": "24 hours"}
+
         except Exception as e:
             logger.error(f"Error sending verification email: {str(e)}")
             raise HTTPException(
                 status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-                detail="Failed to send verification email"
+                detail="Failed to send verification email",
             )
-    
+
     async def verify_email(self, email: str, code: str) -> dict:
         """Verify email with code"""
         try:
             # Find verification record
-            verification = await self.db.email_verifications.find_one({
-                "email": email,
-                "code": code,
-                "is_used": False
-            })
-            
+            verification = await self.db.email_verifications.find_one(
+                {"email": email, "code": code, "is_used": False}
+            )
+
             if not verification:
                 raise HTTPException(
                     status_code=status.HTTP_400_BAD_REQUEST,
-                    detail="Invalid or expired verification code"
+                    detail="Invalid or expired verification code",
                 )
-            
+
             # Check expiry
             if verification["expires_at"] < datetime.utcnow():
                 raise HTTPException(
                     status_code=status.HTTP_400_BAD_REQUEST,
-                    detail="Verification code has expired"
+                    detail="Verification code has expired",
                 )
-            
+
             # Check attempts
             if verification["attempts"] >= 5:
                 raise HTTPException(
                     status_code=status.HTTP_400_BAD_REQUEST,
-                    detail="Too many failed attempts"
+                    detail="Too many failed attempts",
                 )
-            
+
             # Mark as used
             await self.db.email_verifications.update_one(
                 {"_id": verification["_id"]},
-                {"$set": {"is_used": True, "verified_at": datetime.utcnow()}}
+                {"$set": {"is_used": True, "verified_at": datetime.utcnow()}},
             )
-            
+
             # Update user as verified
             await self.db.users.update_one(
                 {"email": email},
                 {
                     "$set": {
                         "email_verified": True,
-                        "email_verified_at": datetime.utcnow()
+                        "email_verified_at": datetime.utcnow(),
                     }
-                }
+                },
             )
-            
+
             return {
                 "message": "Email verified successfully",
-                "verified_at": datetime.utcnow().isoformat()
+                "verified_at": datetime.utcnow().isoformat(),
             }
-            
+
         except HTTPException:
             # Increment attempt count
-            if 'verification' in locals():
+            if "verification" in locals():
                 await self.db.email_verifications.update_one(
-                    {"_id": verification["_id"]},
-                    {"$inc": {"attempts": 1}}
+                    {"_id": verification["_id"]}, {"$inc": {"attempts": 1}}
                 )
             raise
         except Exception as e:
             logger.error(f"Error verifying email: {str(e)}")
             raise HTTPException(
                 status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-                detail="Email verification failed"
+                detail="Email verification failed",
             )
-    
+
     async def export_user_data(self, user_id: str, export_format: str = "json") -> dict:
         """Export all user data for GDPR compliance"""
         try:
@@ -147,14 +153,22 @@ class AccountSecurityService:
             user = await self.db.users.find_one({"id": user_id})
             if not user:
                 raise HTTPException(status.HTTP_404_NOT_FOUND, "User not found")
-            
+
             # Get all related data
-            decisions = await self.db.decision_sessions.find({"user_id": user_id}).to_list(None)
-            conversations = await self.db.conversations.find({"user_id": user_id}).to_list(None)
+            decisions = await self.db.decision_sessions.find(
+                {"user_id": user_id}
+            ).to_list(None)
+            conversations = await self.db.conversations.find(
+                {"user_id": user_id}
+            ).to_list(None)
             payments = await self.db.payments.find({"user_id": user_id}).to_list(None)
-            subscriptions = await self.db.subscriptions.find({"user_id": user_id}).to_list(None)
-            shares = await self.db.decision_shares.find({"user_id": user_id}).to_list(None)
-            
+            subscriptions = await self.db.subscriptions.find(
+                {"user_id": user_id}
+            ).to_list(None)
+            shares = await self.db.decision_shares.find({"user_id": user_id}).to_list(
+                None
+            )
+
             # Clean up ObjectIds and sensitive data
             user_export = self._clean_export_data(user)
             decisions_export = [self._clean_export_data(d) for d in decisions]
@@ -162,12 +176,12 @@ class AccountSecurityService:
             payments_export = [self._clean_export_data(p) for p in payments]
             subscriptions_export = [self._clean_export_data(s) for s in subscriptions]
             shares_export = [self._clean_export_data(sh) for sh in shares]
-            
+
             export_data = {
                 "export_info": {
                     "generated_at": datetime.utcnow().isoformat(),
                     "user_id": user_id,
-                    "export_format": export_format
+                    "export_format": export_format,
                 },
                 "user_profile": user_export,
                 "decisions": decisions_export,
@@ -180,117 +194,143 @@ class AccountSecurityService:
                     "total_conversations": len(conversations),
                     "total_payments": len(payments),
                     "account_created": user.get("created_at"),
-                    "last_active": max([d.get("last_active", datetime.min) for d in decisions] + [datetime.min])
-                }
+                    "last_active": max(
+                        [d.get("last_active", datetime.min) for d in decisions]
+                        + [datetime.min]
+                    ),
+                },
             }
-            
+
             return export_data
-            
+
         except Exception as e:
             logger.error(f"Error exporting user data: {str(e)}")
             raise HTTPException(
                 status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-                detail="Data export failed"
+                detail="Data export failed",
             )
-    
-    async def delete_user_account(self, user_id: str, password: str, confirmation: str) -> dict:
+
+    async def delete_user_account(
+        self, user_id: str, password: str, confirmation: str
+    ) -> dict:
         """Permanently delete user account and all data"""
         try:
             # Verify user and password
             user = await self.db.users.find_one({"id": user_id})
             if not user:
                 raise HTTPException(status.HTTP_404_NOT_FOUND, "User not found")
-            
+
             # Verify password
             from server import verify_password  # Import from main server
+
             if not verify_password(password, user["password_hash"]):
                 raise HTTPException(
-                    status_code=status.HTTP_401_UNAUTHORIZED,
-                    detail="Invalid password"
+                    status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid password"
                 )
-            
+
             # Verify confirmation phrase
             if confirmation != "DELETE_MY_ACCOUNT":
                 raise HTTPException(
                     status_code=status.HTTP_400_BAD_REQUEST,
-                    detail="Invalid confirmation phrase"
+                    detail="Invalid confirmation phrase",
                 )
-            
+
             # Delete all user data
             deletion_results = {}
-            
+
             # Delete user decisions and conversations
-            deletion_results["decisions"] = await self.db.decision_sessions.delete_many({"user_id": user_id})
-            deletion_results["conversations"] = await self.db.conversations.delete_many({"user_id": user_id})
-            
+            deletion_results["decisions"] = await self.db.decision_sessions.delete_many(
+                {"user_id": user_id}
+            )
+            deletion_results["conversations"] = await self.db.conversations.delete_many(
+                {"user_id": user_id}
+            )
+
             # Delete payment and subscription data
-            deletion_results["payments"] = await self.db.payments.delete_many({"user_id": user_id})
-            deletion_results["subscriptions"] = await self.db.subscriptions.delete_many({"user_id": user_id})
-            
+            deletion_results["payments"] = await self.db.payments.delete_many(
+                {"user_id": user_id}
+            )
+            deletion_results["subscriptions"] = await self.db.subscriptions.delete_many(
+                {"user_id": user_id}
+            )
+
             # Delete shared decisions
-            deletion_results["shares"] = await self.db.decision_shares.delete_many({"user_id": user_id})
-            
+            deletion_results["shares"] = await self.db.decision_shares.delete_many(
+                {"user_id": user_id}
+            )
+
             # Delete email verifications
-            deletion_results["verifications"] = await self.db.email_verifications.delete_many({"email": user["email"]})
-            
+            deletion_results[
+                "verifications"
+            ] = await self.db.email_verifications.delete_many({"email": user["email"]})
+
             # Finally delete user account
             deletion_results["user"] = await self.db.users.delete_one({"id": user_id})
-            
+
             # Log deletion for audit
             await self._log_account_deletion(user_id, user["email"], deletion_results)
-            
+
             # Send confirmation email
             await self.email_service.send_account_deletion_confirmation(user["email"])
-            
+
             return {
                 "message": "Account deleted successfully",
                 "deleted_at": datetime.utcnow().isoformat(),
                 "deletion_summary": {
                     "decisions_deleted": deletion_results["decisions"].deleted_count,
-                    "conversations_deleted": deletion_results["conversations"].deleted_count,
+                    "conversations_deleted": deletion_results[
+                        "conversations"
+                    ].deleted_count,
                     "payments_deleted": deletion_results["payments"].deleted_count,
-                    "subscriptions_deleted": deletion_results["subscriptions"].deleted_count,
+                    "subscriptions_deleted": deletion_results[
+                        "subscriptions"
+                    ].deleted_count,
                     "shares_deleted": deletion_results["shares"].deleted_count,
-                    "user_deleted": deletion_results["user"].deleted_count > 0
-                }
+                    "user_deleted": deletion_results["user"].deleted_count > 0,
+                },
             }
-            
+
         except Exception as e:
             logger.error(f"Error deleting user account: {str(e)}")
             raise HTTPException(
                 status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-                detail="Account deletion failed"
+                detail="Account deletion failed",
             )
-    
+
     def _clean_export_data(self, data: dict) -> dict:
         """Clean data for export (remove sensitive info and ObjectIds)"""
         if not data:
             return {}
-        
+
         cleaned = data.copy()
-        
+
         # Remove MongoDB ObjectId
         if "_id" in cleaned:
             del cleaned["_id"]
-        
+
         # Remove sensitive fields
         sensitive_fields = [
-            "password_hash", "dodo_payment_id", "dodo_subscription_id",
-            "payment_method", "webhook_signature"
+            "password_hash",
+            "dodo_payment_id",
+            "dodo_subscription_id",
+            "payment_method",
+            "webhook_signature",
         ]
-        
+
         for field in sensitive_fields:
             if field in cleaned:
                 cleaned[field] = "[REDACTED]"
-        
+
         # Convert datetime objects to ISO strings
         for key, value in cleaned.items():
             if isinstance(value, datetime):
                 cleaned[key] = value.isoformat()
-        
+
         return cleaned
-    
-    async def _log_account_deletion(self, user_id: str, email: str, deletion_results: dict):
+
+    async def _log_account_deletion(
+        self, user_id: str, email: str, deletion_results: dict
+    ):
         """Log account deletion for audit purposes"""
         log_entry = {
             "event_type": "account_deletion",
@@ -298,29 +338,30 @@ class AccountSecurityService:
             "email": email,
             "timestamp": datetime.utcnow(),
             "deletion_results": deletion_results,
-            "requester_ip": "system"  # In real implementation, get from request
+            "requester_ip": "system",  # In real implementation, get from request
         }
-        
+
         # Store in audit log collection
         await self.db.audit_logs.insert_one(log_entry)
-        
+
         # Also log to file
         logger.warning(f"Account deleted: user_id={user_id}, email={email}")
 
+
 class EmailService:
     """Service for sending emails"""
-    
+
     def __init__(self):
         self.smtp_server = os.environ.get("SMTP_SERVER", "smtp.gmail.com")
         self.smtp_port = int(os.environ.get("SMTP_PORT", "587"))
         self.smtp_username = os.environ.get("SMTP_USERNAME", "")
         self.smtp_password = os.environ.get("SMTP_PASSWORD", "")
         self.from_email = os.environ.get("FROM_EMAIL", "noreply@choicepilot.ai")
-    
+
     async def send_verification_email(self, to_email: str, verification_code: str):
         """Send email verification code"""
         subject = "Verify Your ChoicePilot Account"
-        
+
         html_content = f"""
         <html>
             <body>
@@ -334,13 +375,13 @@ class EmailService:
             </body>
         </html>
         """
-        
+
         await self._send_email(to_email, subject, html_content)
-    
+
     async def send_account_deletion_confirmation(self, to_email: str):
         """Send account deletion confirmation"""
         subject = "ChoicePilot Account Deleted"
-        
+
         html_content = """
         <html>
             <body>
@@ -352,13 +393,13 @@ class EmailService:
             </body>
         </html>
         """
-        
+
         await self._send_email(to_email, subject, html_content)
-    
+
     async def send_security_alert(self, to_email: str, event_type: str, details: str):
         """Send security alert email"""
         subject = f"ChoicePilot Security Alert: {event_type}"
-        
+
         html_content = f"""
         <html>
             <body>
@@ -373,32 +414,32 @@ class EmailService:
             </body>
         </html>
         """
-        
+
         await self._send_email(to_email, subject, html_content)
-    
+
     async def _send_email(self, to_email: str, subject: str, html_content: str):
         """Send email using SMTP"""
         try:
             if not self.smtp_username or not self.smtp_password:
                 logger.warning("SMTP credentials not configured, skipping email")
                 return
-            
+
             msg = MIMEMultipart("alternative")
             msg["Subject"] = subject
             msg["From"] = self.from_email
             msg["To"] = to_email
-            
+
             html_part = MIMEText(html_content, "html")
             msg.attach(html_part)
-            
+
             # Send email
             with smtplib.SMTP(self.smtp_server, self.smtp_port) as server:
                 server.starttls()
                 server.login(self.smtp_username, self.smtp_password)
                 server.send_message(msg)
-            
+
             logger.info(f"Email sent successfully to {to_email}")
-            
+
         except Exception as e:
             logger.error(f"Failed to send email to {to_email}: {str(e)}")
             # Don't raise exception - email failures shouldn't break the app

--- a/backend/server.py
+++ b/backend/server.py
@@ -5,8 +5,12 @@ from dotenv import load_dotenv
 from starlette.middleware.cors import CORSMiddleware
 from security_middleware import SecurityMiddleware, CORSSecurityMiddleware
 from account_management import (
-    AccountSecurityService, EmailVerificationRequest, EmailVerificationConfirm,
-    AccountDeletionRequest, DataExportRequest, PrivacySettings
+    AccountSecurityService,
+    EmailVerificationRequest,
+    EmailVerificationConfirm,
+    AccountDeletionRequest,
+    DataExportRequest,
+    PrivacySettings,
 )
 from motor.motor_asyncio import AsyncIOMotorClient
 import os
@@ -32,37 +36,56 @@ import io
 sys.path.append(os.path.dirname(os.path.abspath(__file__)))
 
 from payment_models import (
-    PaymentRequest, SubscriptionRequest, PaymentDocument, SubscriptionDocument,
-    CREDIT_PACKS, SUBSCRIPTION_PRODUCTS, PaymentResponse, SubscriptionResponse,
-    BillingHistory, WebhookPayload
+    PaymentRequest,
+    SubscriptionRequest,
+    PaymentDocument,
+    SubscriptionDocument,
+    CREDIT_PACKS,
+    SUBSCRIPTION_PRODUCTS,
+    PaymentResponse,
+    SubscriptionResponse,
+    BillingHistory,
+    WebhookPayload,
 )
 from payment_service import DodoPaymentsService
-from export_service import DecisionPDFExporter, DecisionSharingService, DecisionComparisonService
+from export_service import (
+    DecisionPDFExporter,
+    DecisionSharingService,
+    DecisionComparisonService,
+)
 from email_service import EmailService, EmailVerificationService
-from monitoring_service import SecurityMonitor, SystemMonitor, BackupManager, AuditLogger
+from monitoring_service import (
+    SecurityMonitor,
+    SystemMonitor,
+    BackupManager,
+    AuditLogger,
+)
 
 
 ROOT_DIR = Path(__file__).parent
-load_dotenv(ROOT_DIR / '.env')
+load_dotenv(ROOT_DIR / ".env")
 
 # MongoDB connection
-mongo_url = os.environ['MONGO_URL']
+mongo_url = os.environ["MONGO_URL"]
 client = AsyncIOMotorClient(mongo_url)
-db = client[os.environ['DB_NAME']]
+db = client[os.environ["DB_NAME"]]
 
 # Create the main app without a prefix
-app = FastAPI(title="ChoicePilot API", description="AI-powered decision assistant with monetization")
+app = FastAPI(
+    title="ChoicePilot API",
+    description="AI-powered decision assistant with monetization",
+)
 
 # Create a router with the /api prefix
 api_router = APIRouter(prefix="/api")
 
 # Get API keys from environment
-ANTHROPIC_API_KEY = os.environ.get('ANTHROPIC_API_KEY')
-OPENAI_API_KEY = os.environ.get('OPENAI_API_KEY')
-JWT_SECRET = os.environ.get('JWT_SECRET', 'your-secret-key-change-this')
-DODO_API_KEY = os.environ.get('DODO_API_KEY')
-DODO_WEBHOOK_SECRET = os.environ.get('DODO_WEBHOOK_SECRET')
-FRONTEND_URL = os.environ.get('FRONTEND_URL')
+ANTHROPIC_API_KEY = os.environ.get("ANTHROPIC_API_KEY")
+OPENAI_API_KEY = os.environ.get("OPENAI_API_KEY")
+JWT_SECRET = os.environ.get("JWT_SECRET", "your-secret-key-change-this")
+DODO_API_KEY = os.environ.get("DODO_API_KEY")
+DODO_WEBHOOK_SECRET = os.environ.get("DODO_WEBHOOK_SECRET")
+FRONTEND_URL = os.environ.get("FRONTEND_URL")
 
 # Security
 security = HTTPBearer()
@@ -81,6 +104,7 @@ system_monitor = SystemMonitor(db)
 backup_manager = BackupManager(db)
 audit_logger = AuditLogger(db)
 
+
 # Basic security features
 class BasicSecurityService:
     @staticmethod
@@ -88,25 +112,26 @@ class BasicSecurityService:
         """Basic input sanitization"""
         if not text:
             return text
-        
+
         # Remove dangerous patterns
         dangerous_patterns = [
-            r'(?i)ignore\s+previous\s+instructions',
-            r'(?i)system\s*:',
-            r'(?i)assistant\s*:',
-            r'(?i)you\s+are\s+now',
-            r'<script[^>]*>.*?</script>',
-            r'javascript:',
+            r"(?i)ignore\s+previous\s+instructions",
+            r"(?i)system\s*:",
+            r"(?i)assistant\s*:",
+            r"(?i)you\s+are\s+now",
+            r"<script[^>]*>.*?</script>",
+            r"javascript:",
         ]
-        
+
         for pattern in dangerous_patterns:
-            text = re.sub(pattern, '[FILTERED]', text)
-        
+            text = re.sub(pattern, "[FILTERED]", text)
+
         # Limit length
         if len(text) > 10000:
             text = text[:10000] + "... [TRUNCATED]"
-        
+
         return text.strip()
+
 
 security_service = BasicSecurityService()
 account_security = AccountSecurityService(db)
@@ -117,26 +142,33 @@ SUBSCRIPTION_PLANS = {
         "name": "Free Plan",
         "price": 0,
         "monthly_decisions": 3,
-        "features": ["3 decision sessions per month", "Basic AI guidance", "Core decision flow"],
-        "restrictions": ["Limited sessions", "No advanced features"]
+        "features": [
+            "3 decision sessions per month",
+            "Basic AI guidance",
+            "Core decision flow",
+        ],
+        "restrictions": ["Limited sessions", "No advanced features"],
     },
     "pro": {
-        "name": "Pro Plan", 
+        "name": "Pro Plan",
         "price": 7.00,  # Updated from 12.00 to 7.00
         "monthly_decisions": -1,  # Unlimited
         "features": [
-            "Unlimited decision sessions", "Advanced AI analysis", "Decision history & export",
-            "Priority support", "Advanced reasoning insights"
+            "Unlimited decision sessions",
+            "Advanced AI analysis",
+            "Decision history & export",
+            "Priority support",
+            "Advanced reasoning insights",
         ],
-        "restrictions": []
-    }
+        "restrictions": [],
+    },
 }
 
 # Credit Packs
 CREDIT_PACKS = {
     "starter": {"name": "Starter Pack", "price": 5.00, "credits": 10},
     "power": {"name": "Power Pack", "price": 10.00, "credits": 25},
-    "boost": {"name": "Pro Boost", "price": 8.00, "credits": 40}
+    "boost": {"name": "Pro Boost", "price": 8.00, "credits": 40},
 }
 
 # Credit Usage
@@ -145,7 +177,7 @@ CREDIT_COSTS = {
     "voice_decision": 2,
     "multi_advisor": 3,
     "export": 1,
-    "scoring_matrix": 2
+    "scoring_matrix": 2,
 }
 
 # Enhanced LLM Models with cost-effectiveness routing
@@ -153,142 +185,236 @@ LLM_MODELS = {
     "claude-sonnet": {
         "provider": "anthropic",
         "model": "claude-sonnet-4-20250514",
-        "strengths": ["logical reasoning", "structured analysis", "emotional intelligence", "detailed explanations"],
+        "strengths": [
+            "logical reasoning",
+            "structured analysis",
+            "emotional intelligence",
+            "detailed explanations",
+        ],
         "best_for": ["career", "financial", "education", "lifestyle"],
         "cost": "high",
-        "pro_only": True
+        "pro_only": True,
     },
     "claude-haiku": {
         "provider": "anthropic",
         "model": "claude-haiku-3-20240307",
-        "strengths": ["fast responses", "nuanced understanding", "empathy", "cost-effective"],
+        "strengths": [
+            "fast responses",
+            "nuanced understanding",
+            "empathy",
+            "cost-effective",
+        ],
         "best_for": ["emotional decisions", "reassurance", "quick analysis"],
         "cost": "low",
-        "pro_only": False
+        "pro_only": False,
     },
     "gpt4o": {
-        "provider": "openai", 
+        "provider": "openai",
         "model": "gpt-4o",
-        "strengths": ["creativity", "real-time interaction", "conversational flow", "detailed reasoning"],
+        "strengths": [
+            "creativity",
+            "real-time interaction",
+            "conversational flow",
+            "detailed reasoning",
+        ],
         "best_for": ["consumer", "travel", "entertainment", "general"],
         "cost": "high",
-        "pro_only": False
+        "pro_only": False,
     },
     "gpt4o-mini": {
-        "provider": "openai", 
+        "provider": "openai",
         "model": "gpt-4o-mini",
-        "strengths": ["fast responses", "logical reasoning", "cost-effective", "structured thinking"],
+        "strengths": [
+            "fast responses",
+            "logical reasoning",
+            "cost-effective",
+            "structured thinking",
+        ],
         "best_for": ["simple decisions", "clarity", "validation"],
         "cost": "low",
-        "pro_only": False
-    }
+        "pro_only": False,
+    },
 }
 
 # Decision Classification System
 DECISION_COMPLEXITY = {
     "LOW": "Simple, factual, or straightforward decisions",
-    "MEDIUM": "Multi-factor or contextual decisions", 
-    "HIGH": "Ambiguous, emotional, or deeply personal decisions"
+    "MEDIUM": "Multi-factor or contextual decisions",
+    "HIGH": "Ambiguous, emotional, or deeply personal decisions",
 }
 
 EMOTIONAL_INTENT = {
     "CLARITY": "User seeks direction or simplicity",
     "CONFIDENCE": "User seeks to validate or confirm a choice",
     "REASSURANCE": "User needs support, safety, or empathy",
-    "EMPOWERMENT": "User wants bold insight or a confidence boost"
+    "EMPOWERMENT": "User wants bold insight or a confidence boost",
 }
 
 # Enhanced Advisor Personas
 ADVISOR_STYLES = {
     "optimistic": {
-        "name": "Sunny", "icon": "🌟", "avatar": "✨", "color": "amber",
+        "name": "Sunny",
+        "icon": "🌟",
+        "avatar": "✨",
+        "color": "amber",
         "description": "Encouraging, focuses on opportunities and positive outcomes",
-        "tone": "upbeat and encouraging", "decision_weight": "opportunity-focused",
-        "language_style": "inspiring and action-oriented", "framework": "Opportunity-First Analysis",
-        "traits": ["uplifting", "reframes positively", "encourages action", "sees potential"],
-        "motto": "Every decision opens new doors", "pro_only": True
+        "tone": "upbeat and encouraging",
+        "decision_weight": "opportunity-focused",
+        "language_style": "inspiring and action-oriented",
+        "framework": "Opportunity-First Analysis",
+        "traits": [
+            "uplifting",
+            "reframes positively",
+            "encourages action",
+            "sees potential",
+        ],
+        "motto": "Every decision opens new doors",
+        "pro_only": True,
     },
     "realist": {
-        "name": "Grounded", "icon": "⚖️", "avatar": "📏", "color": "blue",
+        "name": "Grounded",
+        "icon": "⚖️",
+        "avatar": "📏",
+        "color": "blue",
         "description": "Balanced, practical, objective analysis with measured approach",
-        "tone": "neutral and analytical", "decision_weight": "balanced consideration",
-        "language_style": "structured and efficient", "framework": "Weighted Pros/Cons Analysis",
+        "tone": "neutral and analytical",
+        "decision_weight": "balanced consideration",
+        "language_style": "structured and efficient",
+        "framework": "Weighted Pros/Cons Analysis",
         "traits": ["balanced", "practical", "objective", "efficient"],
-        "motto": "Clear thinking leads to clear choices", "pro_only": False
+        "motto": "Clear thinking leads to clear choices",
+        "pro_only": False,
     },
     "skeptical": {
-        "name": "Spice", "icon": "🔍", "avatar": "🛡️", "color": "red",
+        "name": "Spice",
+        "icon": "🔍",
+        "avatar": "🛡️",
+        "color": "red",
         "description": "Cautious, thorough, risk-focused with deep analysis",
-        "tone": "careful and questioning", "decision_weight": "risk-averse",
-        "language_style": "detailed with caveats", "framework": "Risk Assessment & Mitigation",
+        "tone": "careful and questioning",
+        "decision_weight": "risk-averse",
+        "language_style": "detailed with caveats",
+        "framework": "Risk Assessment & Mitigation",
         "traits": ["cautious", "thorough", "risk-aware", "validates assumptions"],
-        "motto": "Better safe than sorry - let's examine the risks", "pro_only": True
+        "motto": "Better safe than sorry - let's examine the risks",
+        "pro_only": True,
     },
     "creative": {
-        "name": "Creative", "icon": "🎨", "avatar": "💡", "color": "purple",
+        "name": "Creative",
+        "icon": "🎨",
+        "avatar": "💡",
+        "color": "purple",
         "description": "Imaginative, lateral thinking, out-of-the-box ideas",
-        "tone": "playful and imaginative", "decision_weight": "innovation-focused",
-        "language_style": "metaphor-rich and inspiring", "framework": "Creative Exploration & Reframing",
-        "traits": ["imaginative", "metaphor-rich", "reframes problems", "suggests alternatives"],
-        "motto": "What if we looked at this completely differently?", "pro_only": True
+        "tone": "playful and imaginative",
+        "decision_weight": "innovation-focused",
+        "language_style": "metaphor-rich and inspiring",
+        "framework": "Creative Exploration & Reframing",
+        "traits": [
+            "imaginative",
+            "metaphor-rich",
+            "reframes problems",
+            "suggests alternatives",
+        ],
+        "motto": "What if we looked at this completely differently?",
+        "pro_only": True,
     },
     "analytical": {
-        "name": "Analytical", "icon": "📊", "avatar": "🔢", "color": "indigo",
+        "name": "Analytical",
+        "icon": "📊",
+        "avatar": "🔢",
+        "color": "indigo",
         "description": "Data-heavy, methodical, logic-first approach",
-        "tone": "precise and methodical", "decision_weight": "data-driven",
-        "language_style": "structured with numbers", "framework": "Quantitative Decision Matrix",
+        "tone": "precise and methodical",
+        "decision_weight": "data-driven",
+        "language_style": "structured with numbers",
+        "framework": "Quantitative Decision Matrix",
         "traits": ["precise", "data-focused", "methodical", "evidence-based"],
-        "motto": "Let the numbers guide us to the right answer", "pro_only": True
+        "motto": "Let the numbers guide us to the right answer",
+        "pro_only": True,
     },
     "intuitive": {
-        "name": "Intuitive", "icon": "🌙", "avatar": "💫", "color": "pink",
+        "name": "Intuitive",
+        "icon": "🌙",
+        "avatar": "💫",
+        "color": "pink",
         "description": "Emotion-led, gut feeling, holistic understanding",
-        "tone": "warm and insightful", "decision_weight": "feeling-based",
-        "language_style": "empathetic and flowing", "framework": "Gut Check & Alignment Analysis",
+        "tone": "warm and insightful",
+        "decision_weight": "feeling-based",
+        "language_style": "empathetic and flowing",
+        "framework": "Gut Check & Alignment Analysis",
         "traits": ["empathetic", "emotionally attuned", "holistic", "intuitive"],
-        "motto": "What does your heart tell you?", "pro_only": True
+        "motto": "What does your heart tell you?",
+        "pro_only": True,
     },
     "visionary": {
-        "name": "Visionary", "icon": "🚀", "avatar": "🔮", "color": "emerald",
+        "name": "Visionary",
+        "icon": "🚀",
+        "avatar": "🔮",
+        "color": "emerald",
         "description": "Future-oriented, strategic, high-impact thinking",
-        "tone": "inspiring and strategic", "decision_weight": "future-focused",
-        "language_style": "bold and forward-thinking", "framework": "Strategic Future Mapping",
+        "tone": "inspiring and strategic",
+        "decision_weight": "future-focused",
+        "language_style": "bold and forward-thinking",
+        "framework": "Strategic Future Mapping",
         "traits": ["strategic", "future-oriented", "bold", "transformative"],
-        "motto": "How will this decision shape your future?", "pro_only": True
+        "motto": "How will this decision shape your future?",
+        "pro_only": True,
     },
     "supportive": {
-        "name": "Supportive", "icon": "🤝", "avatar": "💙", "color": "green",
+        "name": "Supportive",
+        "icon": "🤝",
+        "avatar": "💙",
+        "color": "green",
         "description": "Empathetic, validating, emotionally intelligent",
-        "tone": "warm and understanding", "decision_weight": "emotional well-being",
-        "language_style": "gentle and affirming", "framework": "Emotional Alignment & Well-being",
+        "tone": "warm and understanding",
+        "decision_weight": "emotional well-being",
+        "language_style": "gentle and affirming",
+        "framework": "Emotional Alignment & Well-being",
         "traits": ["empathetic", "validating", "supportive", "understanding"],
-        "motto": "You've got this - let's find what feels right", "pro_only": True
-    }
+        "motto": "You've got this - let's find what feels right",
+        "pro_only": True,
+    },
 }
 
 # Follow-up Question Personas (Streamlined for Smart Questions)
 FOLLOWUP_PERSONAS = {
     "realist": {
-        "name": "Realist", "icon": "🧠", "color": "blue",
-        "style": "practical and direct", "focus": "facts and constraints"
+        "name": "Realist",
+        "icon": "🧠",
+        "color": "blue",
+        "style": "practical and direct",
+        "focus": "facts and constraints",
     },
     "visionary": {
-        "name": "Visionary", "icon": "🚀", "color": "purple", 
-        "style": "inspiring and forward-thinking", "focus": "possibilities and outcomes"
+        "name": "Visionary",
+        "icon": "🚀",
+        "color": "purple",
+        "style": "inspiring and forward-thinking",
+        "focus": "possibilities and outcomes",
     },
     "creative": {
-        "name": "Creative", "icon": "🎨", "color": "pink",
-        "style": "imaginative and lateral", "focus": "alternatives and innovation"
+        "name": "Creative",
+        "icon": "🎨",
+        "color": "pink",
+        "style": "imaginative and lateral",
+        "focus": "alternatives and innovation",
     },
     "pragmatist": {
-        "name": "Pragmatist", "icon": "⚖️", "color": "green",
-        "style": "balanced and systematic", "focus": "trade-offs and priorities"
+        "name": "Pragmatist",
+        "icon": "⚖️",
+        "color": "green",
+        "style": "balanced and systematic",
+        "focus": "trade-offs and priorities",
     },
     "supportive": {
-        "name": "Supportive", "icon": "💙", "color": "teal",
-        "style": "empathetic and validating", "focus": "emotions and well-being"
-    }
+        "name": "Supportive",
+        "icon": "💙",
+        "color": "teal",
+        "style": "empathetic and validating",
+        "focus": "emotions and well-being",
+    },
 }
+
 
 # User and Subscription Models
 class User(BaseModel):
@@ -309,22 +435,27 @@ class User(BaseModel):
     last_reset: datetime = Field(default_factory=datetime.utcnow)
     is_active: bool = True
 
+
 class UserRegistration(BaseModel):
     name: str  # Added name field
     email: EmailStr
     password: str
 
+
 class UserLogin(BaseModel):
     email: EmailStr
     password: str
 
+
 class PasswordResetRequest(BaseModel):
     email: EmailStr
+
 
 class PasswordReset(BaseModel):
     email: EmailStr
     reset_token: str
     new_password: str
+
 
 class SubscriptionInfo(BaseModel):
     plan: str
@@ -335,6 +466,7 @@ class SubscriptionInfo(BaseModel):
     features_available: List[str]
     restrictions: List[str]
 
+
 # Decision models
 class DecisionRequest(BaseModel):
     message: str
@@ -342,8 +474,20 @@ class DecisionRequest(BaseModel):
     category: Optional[str] = None
     preferences: Optional[dict] = None
     llm_preference: Optional[Literal["auto", "claude", "gpt4o"]] = "auto"
-    advisor_style: Optional[Literal["optimistic", "realist", "skeptical", "creative", "analytical", "intuitive", "visionary", "supportive"]] = "realist"
+    advisor_style: Optional[
+        Literal[
+            "optimistic",
+            "realist",
+            "skeptical",
+            "creative",
+            "analytical",
+            "intuitive",
+            "visionary",
+            "supportive",
+        ]
+    ] = "realist"
     use_voice: bool = False
+
 
 class DecisionResponse(BaseModel):
     decision_id: str
@@ -355,6 +499,7 @@ class DecisionResponse(BaseModel):
     advisor_personality: dict
     credits_used: int
     timestamp: datetime = Field(default_factory=datetime.utcnow)
+
 
 class ConversationHistory(BaseModel):
     id: str = Field(default_factory=lambda: str(uuid.uuid4()))
@@ -369,6 +514,7 @@ class ConversationHistory(BaseModel):
     advisor_personality: Optional[dict] = None
     credits_used: int = 0
     timestamp: datetime = Field(default_factory=datetime.utcnow)
+
 
 class DecisionSession(BaseModel):
     id: str = Field(default_factory=lambda: str(uuid.uuid4()))
@@ -385,6 +531,7 @@ class DecisionSession(BaseModel):
     last_active: datetime = Field(default_factory=datetime.utcnow)
     is_active: bool = True
 
+
 # New Decision Session Models for structured flow
 class DecisionStepRequest(BaseModel):
     message: str
@@ -392,16 +539,19 @@ class DecisionStepRequest(BaseModel):
     step: Literal["initial", "followup", "adjust"] = "initial"
     step_number: Optional[int] = None
 
+
 class DecisionFollowUpQuestion(BaseModel):
     question: str
     step_number: int
     context: str
+
 
 class DecisionRecommendation(BaseModel):
     recommendation: str
     confidence_score: float  # 0-100
     reasoning: str
     action_link: Optional[str] = None
+
 
 class DecisionSessionNew(BaseModel):
     id: str = Field(default_factory=lambda: str(uuid.uuid4()))
@@ -410,25 +560,26 @@ class DecisionSessionNew(BaseModel):
     category: Optional[str] = None
     current_step: Literal["collecting", "followup", "complete"] = "collecting"
     step_number: int = 0
-    
+
     # Follow-up questions and answers
     followup_questions: List[DecisionFollowUpQuestion] = []
     followup_answers: List[str] = []
-    
+
     # Final recommendation
     recommendation: Optional[DecisionRecommendation] = None
-    
+
     # Feedback
     feedback_helpful: Optional[bool] = None
     feedback_text: Optional[str] = None
-    
+
     # Adjustments
     adjustment_count: int = 0
-    
+
     # Metadata
     created_at: datetime = Field(default_factory=datetime.utcnow)
     completed_at: Optional[datetime] = None
     last_active: datetime = Field(default_factory=datetime.utcnow)
+
 
 class DecisionStepResponse(BaseModel):
     decision_id: str
@@ -439,6 +590,7 @@ class DecisionStepResponse(BaseModel):
     followup_question: Optional[DecisionFollowUpQuestion] = None
     recommendation: Optional[DecisionRecommendation] = None
 
+
 # Enhanced Decision Step Models for Advanced AI Orchestration
 class AdvancedDecisionStepRequest(BaseModel):
     message: str
@@ -448,12 +600,14 @@ class AdvancedDecisionStepRequest(BaseModel):
     enable_personalization: bool = False
     adjustment_context: Optional[str] = None
 
+
 class EnhancedFollowUpQuestion(BaseModel):
     question: str
     nudge: str
     category: str
     step_number: int
     persona: str = "realist"  # Added persona field with default
+
 
 class EnhancedDecisionTrace(BaseModel):
     models_used: List[str]
@@ -464,6 +618,7 @@ class EnhancedDecisionTrace(BaseModel):
     personas_consulted: List[str]
     processing_time_ms: int
 
+
 class EnhancedDecisionRecommendation(BaseModel):
     final_recommendation: str
     summary: str  # New: 1-paragraph TL;DR summary
@@ -473,6 +628,7 @@ class EnhancedDecisionRecommendation(BaseModel):
     confidence_tooltip: str
     reasoning: str
     trace: EnhancedDecisionTrace
+
 
 class AdvancedDecisionStepResponse(BaseModel):
     decision_id: str
@@ -485,17 +641,19 @@ class AdvancedDecisionStepResponse(BaseModel):
     decision_type: Optional[str] = None
     session_version: int = 1
 
+
 # Decision categories
 DECISION_CATEGORIES = {
     "general": "General decision making and advice",
     "consumer": "Product purchases and consumer electronics",
-    "travel": "Travel planning and destination choices", 
+    "travel": "Travel planning and destination choices",
     "career": "Career moves and professional decisions",
     "education": "Learning and educational choices",
     "lifestyle": "Health, fitness, and lifestyle decisions",
     "entertainment": "Movies, books, games, and entertainment",
-    "financial": "Financial planning and investment decisions"
+    "financial": "Financial planning and investment decisions",
 }
+
 
 # Authentication and Authorization
 def hash_password(password: str) -> str:
@@ -504,128 +662,155 @@ def hash_password(password: str) -> str:
     password_hash = hashlib.sha256((password + salt).encode()).hexdigest()
     return f"{salt}:{password_hash}"
 
+
 def verify_password(password: str, stored_hash: str) -> bool:
     """Verify password against stored hash"""
     try:
-        salt, hash_value = stored_hash.split(':')
+        salt, hash_value = stored_hash.split(":")
         return hashlib.sha256((password + salt).encode()).hexdigest() == hash_value
     except:
         return False
+
 
 def create_access_token(user_id: str, email: str) -> str:
     """Create JWT access token"""
     payload = {
         "user_id": user_id,
         "email": email,
-        "exp": datetime.utcnow() + timedelta(days=30)
+        "exp": datetime.utcnow() + timedelta(days=30),
     }
     return jwt.encode(payload, JWT_SECRET, algorithm="HS256")
 
-async def get_current_user_optional(credentials: HTTPAuthorizationCredentials = Depends(HTTPBearer(auto_error=False))) -> Optional[dict]:
+
+async def get_current_user_optional(
+    credentials: HTTPAuthorizationCredentials = Depends(HTTPBearer(auto_error=False)),
+) -> Optional[dict]:
     """Get current user but return None if not authenticated (no error)"""
     if not credentials:
         return None
     try:
         payload = jwt.decode(credentials.credentials, JWT_SECRET, algorithms=["HS256"])
         user_id = payload.get("user_id")
-        
+
         if not user_id:
             return None
-        
+
         user = await db.users.find_one({"id": user_id})
         if not user or not user.get("is_active"):
             return None
-        
+
         return user
     except:
         return None
 
-async def get_current_user(credentials: HTTPAuthorizationCredentials = Depends(security)) -> dict:
+
+async def get_current_user(
+    credentials: HTTPAuthorizationCredentials = Depends(security),
+) -> dict:
     """Get current user from JWT token"""
     try:
         payload = jwt.decode(credentials.credentials, JWT_SECRET, algorithms=["HS256"])
         user_id = payload.get("user_id")
         email = payload.get("email")
-        
+
         if not user_id:
             raise HTTPException(status.HTTP_401_UNAUTHORIZED, "Invalid token")
-        
+
         user = await db.users.find_one({"id": user_id})
         if not user or not user.get("is_active"):
-            raise HTTPException(status.HTTP_401_UNAUTHORIZED, "User not found or inactive")
-        
+            raise HTTPException(
+                status.HTTP_401_UNAUTHORIZED, "User not found or inactive"
+            )
+
         return user
     except jwt.ExpiredSignatureError:
         raise HTTPException(status.HTTP_401_UNAUTHORIZED, "Token expired")
     except jwt.InvalidTokenError:
         raise HTTPException(status.HTTP_401_UNAUTHORIZED, "Invalid token")
 
-async def check_usage_and_permissions(user: dict, use_voice: bool = False, advisor_style: str = "realist", llm_preference: str = "auto") -> dict:
+
+async def check_usage_and_permissions(
+    user: dict,
+    use_voice: bool = False,
+    advisor_style: str = "realist",
+    llm_preference: str = "auto",
+) -> dict:
     """Check if user has permissions and credits for the requested action"""
     now = datetime.utcnow()
-    
+
     # Reset monthly counter if it's a new month
     last_reset = user.get("last_reset", now)
     if isinstance(last_reset, str):
-        last_reset = datetime.fromisoformat(last_reset.replace('Z', '+00:00'))
-    
+        last_reset = datetime.fromisoformat(last_reset.replace("Z", "+00:00"))
+
     if last_reset.month != now.month or last_reset.year != now.year:
         await db.users.update_one(
             {"id": user["id"]},
-            {"$set": {"monthly_decisions_used": 0, "last_reset": now}}
+            {"$set": {"monthly_decisions_used": 0, "last_reset": now}},
         )
         user["monthly_decisions_used"] = 0
-    
+
     plan = user.get("plan", "free")
     monthly_used = user.get("monthly_decisions_used", 0)
     credits = user.get("credits", 0)
-    
+
     # Check subscription expiry for pro users
     if plan == "pro":
         subscription_expires = user.get("subscription_expires")
         if subscription_expires and isinstance(subscription_expires, str):
-            subscription_expires = datetime.fromisoformat(subscription_expires.replace('Z', '+00:00'))
-        
+            subscription_expires = datetime.fromisoformat(
+                subscription_expires.replace("Z", "+00:00")
+            )
+
         if subscription_expires and subscription_expires < now:
             # Downgrade to free plan
-            await db.users.update_one(
-                {"id": user["id"]},
-                {"$set": {"plan": "free"}}
-            )
+            await db.users.update_one({"id": user["id"]}, {"$set": {"plan": "free"}})
             plan = "free"
-    
+
     # Calculate credit cost
     if use_voice:
         credit_cost = CREDIT_COSTS["voice_decision"]
     else:
         credit_cost = CREDIT_COSTS["text_decision"]
-    
+
     # Check permissions
     errors = []
-    
+
     # Check advisor permissions
     if ADVISOR_STYLES.get(advisor_style, {}).get("pro_only", False) and plan != "pro":
         errors.append(f"Advisor '{advisor_style}' requires Pro subscription")
-    
+
     # Check LLM permissions
-    if llm_preference == "claude" and LLM_MODELS["claude"]["pro_only"] and plan != "pro":
+    if (
+        llm_preference == "claude"
+        and LLM_MODELS["claude"]["pro_only"]
+        and plan != "pro"
+    ):
         errors.append("Claude AI requires Pro subscription")
-    
+
     # Check decision limits
     if plan == "free":
         monthly_limit = SUBSCRIPTION_PLANS["free"]["monthly_decisions"]
         if monthly_used >= monthly_limit and credits < credit_cost:
-            errors.append(f"Monthly limit reached ({monthly_limit} decisions). Upgrade to Pro or buy credits.")
-    
+            errors.append(
+                f"Monthly limit reached ({monthly_limit} decisions). Upgrade to Pro or buy credits."
+            )
+
     # Check credit balance
-    if plan == "free" and monthly_used >= SUBSCRIPTION_PLANS["free"]["monthly_decisions"]:
+    if (
+        plan == "free"
+        and monthly_used >= SUBSCRIPTION_PLANS["free"]["monthly_decisions"]
+    ):
         if credits < credit_cost:
-            errors.append(f"Insufficient credits. Need {credit_cost} credits for this action.")
-    
+            errors.append(
+                f"Insufficient credits. Need {credit_cost} credits for this action."
+            )
+
     if errors:
         return {"allowed": False, "errors": errors, "credit_cost": credit_cost}
-    
+
     return {"allowed": True, "errors": [], "credit_cost": credit_cost}
+
 
 # Enhanced authentication endpoints with security
 @api_router.post("/auth/register")
@@ -633,72 +818,88 @@ async def register_user(user_data: UserRegistration):
     """Register a new user with enhanced security"""
     try:
         # Enhanced input validation
-        
+
         # Name validation - only alphabetic characters and spaces
         if not user_data.name or not user_data.name.strip():
             raise HTTPException(status.HTTP_400_BAD_REQUEST, "Name is required")
-        
-        name_pattern = r'^[a-zA-Z\s]+$'
+
+        name_pattern = r"^[a-zA-Z\s]+$"
         if not re.match(name_pattern, user_data.name.strip()):
-            raise HTTPException(status.HTTP_400_BAD_REQUEST, "Name must contain only letters and spaces")
-        
+            raise HTTPException(
+                status.HTTP_400_BAD_REQUEST, "Name must contain only letters and spaces"
+            )
+
         if len(user_data.name.strip()) < 2:
-            raise HTTPException(status.HTTP_400_BAD_REQUEST, "Name must be at least 2 characters long")
-        
+            raise HTTPException(
+                status.HTTP_400_BAD_REQUEST, "Name must be at least 2 characters long"
+            )
+
         # Email validation
-        email_pattern = r'^[^\s@]+@[^\s@]+\.[^\s@]+$'
+        email_pattern = r"^[^\s@]+@[^\s@]+\.[^\s@]+$"
         if not re.match(email_pattern, user_data.email):
-            raise HTTPException(status.HTTP_400_BAD_REQUEST, "Please enter a valid email address")
-        
+            raise HTTPException(
+                status.HTTP_400_BAD_REQUEST, "Please enter a valid email address"
+            )
+
         # Enhanced password validation
         if len(user_data.password) < 8:
-            raise HTTPException(status.HTTP_400_BAD_REQUEST, "Password must be at least 8 characters")
-        
+            raise HTTPException(
+                status.HTTP_400_BAD_REQUEST, "Password must be at least 8 characters"
+            )
+
         # Check for uppercase letter
-        if not re.search(r'[A-Z]', user_data.password):
-            raise HTTPException(status.HTTP_400_BAD_REQUEST, "Password must contain at least one uppercase letter")
-        
+        if not re.search(r"[A-Z]", user_data.password):
+            raise HTTPException(
+                status.HTTP_400_BAD_REQUEST,
+                "Password must contain at least one uppercase letter",
+            )
+
         # Check for lowercase letter
-        if not re.search(r'[a-z]', user_data.password):
-            raise HTTPException(status.HTTP_400_BAD_REQUEST, "Password must contain at least one lowercase letter")
-        
+        if not re.search(r"[a-z]", user_data.password):
+            raise HTTPException(
+                status.HTTP_400_BAD_REQUEST,
+                "Password must contain at least one lowercase letter",
+            )
+
         # Check for number
-        if not re.search(r'\d', user_data.password):
-            raise HTTPException(status.HTTP_400_BAD_REQUEST, "Password must contain at least one number")
-        
+        if not re.search(r"\d", user_data.password):
+            raise HTTPException(
+                status.HTTP_400_BAD_REQUEST, "Password must contain at least one number"
+            )
+
         # Check for special character
         if not re.search(r'[!@#$%^&*(),.?":{}|<>]', user_data.password):
-            raise HTTPException(status.HTTP_400_BAD_REQUEST, "Password must contain at least one special character")
-        
+            raise HTTPException(
+                status.HTTP_400_BAD_REQUEST,
+                "Password must contain at least one special character",
+            )
+
         # Check if user already exists
         existing_user = await db.users.find_one({"email": user_data.email})
         if existing_user:
             raise HTTPException(status.HTTP_400_BAD_REQUEST, "Email already registered")
-        
+
         # Create new user
         password_hash = hash_password(user_data.password)
         user = User(
-            name=user_data.name.strip(),  # Added name field with trim
+            name=user_data.name.strip(),
             email=user_data.email,
             password_hash=password_hash,
             plan="free",
             credits=0,
             monthly_decisions_used=0,
-            email_verified=True  # Temporarily set to True to bypass email issues
         )
-        
+
         await db.users.insert_one(user.dict())
-        
-        # Temporarily disable email verification
-        # Send verification email
-        # try:
-        #     await email_verification_service.send_verification_email(user.email)
-        # except Exception as e:
-        #     logger.warning(f"Failed to send verification email: {str(e)}")
-        
+
+        try:
+            await email_verification_service.send_verification_email(user.email)
+        except Exception as e:
+            logger.warning(f"Failed to send verification email: {str(e)}")
+
         # Create access token
         token = create_access_token(user.id, user.email)
-        
+
         return {
             "message": "User registered successfully.",
             "access_token": token,
@@ -708,14 +909,17 @@ async def register_user(user_data: UserRegistration):
                 "email": user.email,
                 "plan": user.plan,
                 "credits": user.credits,
-                "email_verified": True
-            }
+                "email_verified": False,
+            },
         }
     except HTTPException:
         raise
     except Exception as e:
         logger.error(f"Registration error: {str(e)}")
-        raise HTTPException(status.HTTP_500_INTERNAL_SERVER_ERROR, "Registration failed")
+        raise HTTPException(
+            status.HTTP_500_INTERNAL_SERVER_ERROR, "Registration failed"
+        )
+
 
 @api_router.post("/auth/verify-email")
 async def verify_email(request: dict):
@@ -723,32 +927,46 @@ async def verify_email(request: dict):
     try:
         email = request.get("email")
         code = request.get("verification_code")
-        
+
         if not email or not code:
-            raise HTTPException(status.HTTP_400_BAD_REQUEST, "Email and verification code required")
-        
+            raise HTTPException(
+                status.HTTP_400_BAD_REQUEST, "Email and verification code required"
+            )
+
         return await email_verification_service.verify_email(email, code)
     except HTTPException:
         raise
     except Exception as e:
         logger.error(f"Email verification error: {str(e)}")
-        raise HTTPException(status.HTTP_500_INTERNAL_SERVER_ERROR, "Email verification failed")
+        raise HTTPException(
+            status.HTTP_500_INTERNAL_SERVER_ERROR, "Email verification failed"
+        )
+
 
 @api_router.post("/auth/resend-verification")
 async def resend_verification(request: dict):
     """Resend email verification"""
     try:
         email = request.get("email")
-        
+
         if not email:
             raise HTTPException(status.HTTP_400_BAD_REQUEST, "Email required")
-        
+
         return await email_verification_service.send_verification_email(email)
     except HTTPException:
         raise
     except Exception as e:
         logger.error(f"Resend verification error: {str(e)}")
-        raise HTTPException(status.HTTP_500_INTERNAL_SERVER_ERROR, "Failed to resend verification")
+        raise HTTPException(
+            status.HTTP_500_INTERNAL_SERVER_ERROR, "Failed to resend verification"
+        )
+
+
+@api_router.get("/auth/confirm")
+async def confirm_email(token: str):
+    """Confirm user email via verification token"""
+    return await email_verification_service.verify_email_token(token)
+
 
 @api_router.post("/auth/login")
 async def login_user(login_data: UserLogin):
@@ -758,19 +976,20 @@ async def login_user(login_data: UserLogin):
         if not user or not verify_password(login_data.password, user["password_hash"]):
             # Log failed login attempt
             logger.warning(f"Failed login attempt for email: {login_data.email}")
-            raise HTTPException(status.HTTP_401_UNAUTHORIZED, "Invalid email or password")
-        
+            raise HTTPException(
+                status.HTTP_401_UNAUTHORIZED, "Invalid email or password"
+            )
+
         if not user.get("is_active", True):
             raise HTTPException(status.HTTP_401_UNAUTHORIZED, "Account is inactive")
-        
+
         # Update last login
         await db.users.update_one(
-            {"id": user["id"]},
-            {"$set": {"last_login": datetime.utcnow()}}
+            {"id": user["id"]}, {"$set": {"last_login": datetime.utcnow()}}
         )
-        
+
         token = create_access_token(user["id"], user["email"])
-        
+
         return {
             "message": "Login successful",
             "access_token": token,
@@ -779,14 +998,15 @@ async def login_user(login_data: UserLogin):
                 "email": user["email"],
                 "plan": user["plan"],
                 "credits": user["credits"],
-                "email_verified": user.get("email_verified", False)
-            }
+                "email_verified": user.get("email_verified", False),
+            },
         }
     except HTTPException:
         raise
     except Exception as e:
         logger.error(f"Login error: {str(e)}")
         raise HTTPException(status.HTTP_500_INTERNAL_SERVER_ERROR, "Login failed")
+
 
 @api_router.post("/auth/password-reset-request")
 async def request_password_reset(request: PasswordResetRequest):
@@ -796,7 +1016,7 @@ async def request_password_reset(request: PasswordResetRequest):
         if not user:
             # Don't reveal if email exists
             return {"message": "If the email exists, a reset link has been sent"}
-        
+
         # Generate reset token
         reset_token = secrets.token_urlsafe(32)
         reset_doc = {
@@ -804,62 +1024,72 @@ async def request_password_reset(request: PasswordResetRequest):
             "reset_token": reset_token,
             "created_at": datetime.utcnow(),
             "expires_at": datetime.utcnow() + timedelta(hours=1),
-            "is_used": False
+            "is_used": False,
         }
-        
+
         await db.password_resets.insert_one(reset_doc)
-        
+
         # Send reset email
         try:
             await email_service.send_password_reset_email(request.email, reset_token)
         except Exception as e:
             logger.warning(f"Failed to send password reset email: {str(e)}")
-        
+
         return {"message": "If the email exists, a reset link has been sent"}
-        
+
     except Exception as e:
         logger.error(f"Password reset request error: {str(e)}")
         return {"message": "If the email exists, a reset link has been sent"}
+
 
 @api_router.post("/auth/password-reset")
 async def reset_password(request: PasswordReset):
     """Reset password with token"""
     try:
         # Find reset record
-        reset_record = await db.password_resets.find_one({
-            "email": request.email,
-            "reset_token": request.reset_token,
-            "is_used": False
-        })
-        
+        reset_record = await db.password_resets.find_one(
+            {
+                "email": request.email,
+                "reset_token": request.reset_token,
+                "is_used": False,
+            }
+        )
+
         if not reset_record or reset_record["expires_at"] < datetime.utcnow():
-            raise HTTPException(status.HTTP_400_BAD_REQUEST, "Invalid or expired reset token")
-        
+            raise HTTPException(
+                status.HTTP_400_BAD_REQUEST, "Invalid or expired reset token"
+            )
+
         # Validate new password
         if len(request.new_password) < 8:
-            raise HTTPException(status.HTTP_400_BAD_REQUEST, "Password must be at least 8 characters")
-        
+            raise HTTPException(
+                status.HTTP_400_BAD_REQUEST, "Password must be at least 8 characters"
+            )
+
         # Update password
         password_hash = hash_password(request.new_password)
         await db.users.update_one(
             {"email": request.email},
-            {"$set": {"password_hash": password_hash, "updated_at": datetime.utcnow()}}
+            {"$set": {"password_hash": password_hash, "updated_at": datetime.utcnow()}},
         )
-        
+
         # Mark reset token as used
         await db.password_resets.update_one(
             {"_id": reset_record["_id"]},
-            {"$set": {"is_used": True, "used_at": datetime.utcnow()}}
+            {"$set": {"is_used": True, "used_at": datetime.utcnow()}},
         )
-        
+
         logger.info(f"Password reset successful for email: {request.email}")
         return {"message": "Password reset successfully"}
-        
+
     except HTTPException:
         raise
     except Exception as e:
         logger.error(f"Password reset error: {str(e)}")
-        raise HTTPException(status.HTTP_500_INTERNAL_SERVER_ERROR, "Password reset failed")
+        raise HTTPException(
+            status.HTTP_500_INTERNAL_SERVER_ERROR, "Password reset failed"
+        )
+
 
 @api_router.get("/auth/me")
 async def get_current_user_info(current_user: dict = Depends(get_current_user)):
@@ -872,20 +1102,29 @@ async def get_current_user_info(current_user: dict = Depends(get_current_user)):
         "credits": current_user["credits"],
         "monthly_decisions_used": current_user.get("monthly_decisions_used", 0),
         "subscription_expires": current_user.get("subscription_expires"),
-        "email_verified": current_user.get("email_verified", True),  # Default to True as per the fix
-        "created_at": current_user["created_at"]
+        "email_verified": current_user.get(
+            "email_verified", True
+        ),  # Default to True as per the fix
+        "created_at": current_user["created_at"],
     }
 
+
 @api_router.get("/subscription/info")
-async def get_subscription_info(current_user: dict = Depends(get_current_user)) -> SubscriptionInfo:
+async def get_subscription_info(
+    current_user: dict = Depends(get_current_user),
+) -> SubscriptionInfo:
     """Get user's subscription information and available features"""
     plan = current_user.get("plan", "free")
     monthly_used = current_user.get("monthly_decisions_used", 0)
     credits = current_user.get("credits", 0)
-    
+
     plan_info = SUBSCRIPTION_PLANS[plan]
-    monthly_limit = plan_info["monthly_decisions"] if plan_info["monthly_decisions"] != -1 else 999999
-    
+    monthly_limit = (
+        plan_info["monthly_decisions"]
+        if plan_info["monthly_decisions"] != -1
+        else 999999
+    )
+
     return SubscriptionInfo(
         plan=plan,
         monthly_decisions_used=monthly_used,
@@ -893,8 +1132,9 @@ async def get_subscription_info(current_user: dict = Depends(get_current_user)) 
         credits=credits,
         subscription_expires=current_user.get("subscription_expires"),
         features_available=plan_info["features"],
-        restrictions=plan_info["restrictions"]
+        restrictions=plan_info["restrictions"],
     )
+
 
 @api_router.get("/subscription/plans")
 async def get_subscription_plans():
@@ -902,18 +1142,20 @@ async def get_subscription_plans():
     return {
         "subscription_plans": SUBSCRIPTION_PLANS,
         "credit_packs": CREDIT_PACKS,
-        "credit_costs": CREDIT_COSTS
+        "credit_costs": CREDIT_COSTS,
     }
+
 
 # Enhanced AI Orchestration Classes
 class DecisionClassifier:
     """Classifies decisions by complexity and emotional intent for smart model routing"""
-    
+
     @staticmethod
     async def classify_decision(message: str) -> dict:
         """Classify decision complexity and emotional intent using cost-effective models"""
-        
-        classification_prompt = """You are a decision classifier for an AI assistant.
+
+        classification_prompt = (
+            """You are a decision classifier for an AI assistant.
 
 Given a user's input describing a problem or decision, classify it along two axes:
 
@@ -934,162 +1176,216 @@ Return output in this format:
   "intent": "CLARITY"
 }
 
-User input: """ + message
+User input: """
+            + message
+        )
 
         try:
             # Use cost-effective model for classification
-            chat = LlmChat(
-                api_key=OPENAI_API_KEY,
-                session_id=f"classifier_{uuid.uuid4()}",
-                system_message=classification_prompt
-            ).with_model("openai", "gpt-4o-mini").with_max_tokens(100)
-            
+            chat = (
+                LlmChat(
+                    api_key=OPENAI_API_KEY,
+                    session_id=f"classifier_{uuid.uuid4()}",
+                    system_message=classification_prompt,
+                )
+                .with_model("openai", "gpt-4o-mini")
+                .with_max_tokens(100)
+            )
+
             user_message = UserMessage(text=message)
             response = await chat.send_message(user_message)
-            
+
             # Parse JSON response
             import json
+
             classification = json.loads(response.strip())
-            
+
             # Validate classification
             if classification.get("complexity") not in ["LOW", "MEDIUM", "HIGH"]:
                 classification["complexity"] = "MEDIUM"
-            if classification.get("intent") not in ["CLARITY", "CONFIDENCE", "REASSURANCE", "EMPOWERMENT"]:
+            if classification.get("intent") not in [
+                "CLARITY",
+                "CONFIDENCE",
+                "REASSURANCE",
+                "EMPOWERMENT",
+            ]:
                 classification["intent"] = "CLARITY"
-                
+
             return classification
-            
+
         except Exception as e:
             logging.warning(f"Classification failed: {str(e)}")
             # Fallback classification
             return {"complexity": "MEDIUM", "intent": "CLARITY"}
 
+
 class SmartModelRouter:
     """Routes to optimal models based on classification for cost-effectiveness"""
-    
+
     @staticmethod
     def route_models(classification: dict, user_plan: str = "free") -> list:
         """Route to best models based on complexity and intent"""
-        
+
         complexity = classification.get("complexity", "MEDIUM")
         intent = classification.get("intent", "CLARITY")
-        
+
         # LOW complexity - use cheapest effective model
         if complexity == "LOW":
             return ["gpt4o-mini"]
-        
+
         # MEDIUM complexity - balance cost and capability
         if complexity == "MEDIUM":
             if intent in ["CLARITY", "CONFIDENCE"]:
                 return ["gpt4o-mini"]
             else:  # REASSURANCE, EMPOWERMENT
                 return ["claude-haiku"]
-        
+
         # HIGH complexity - use best models (combo for emotional + logical)
         if complexity == "HIGH":
             if user_plan == "pro":
                 return ["claude-sonnet", "gpt4o-mini"]  # Premium combo
             else:
                 return ["claude-haiku", "gpt4o-mini"]  # Cost-effective combo
-        
+
         # Fallback
         return ["gpt4o-mini"]
+
 
 # LLM Router with monetization
 class LLMRouter:
     """Intelligent LLM routing engine with monetization checks"""
-    
+
     @staticmethod
-    def determine_best_llm(category: str, message: str, user_preference: str = "auto", user_plan: str = "free") -> str:
+    def determine_best_llm(
+        category: str,
+        message: str,
+        user_preference: str = "auto",
+        user_plan: str = "free",
+    ) -> str:
         """Determine the best LLM based on decision type and user plan"""
-        
+
         if user_preference in ["claude", "gpt4o"]:
             # Check if user has access to Claude
-            if user_preference == "claude" and LLM_MODELS["claude"]["pro_only"] and user_plan != "pro":
+            if (
+                user_preference == "claude"
+                and LLM_MODELS["claude"]["pro_only"]
+                and user_plan != "pro"
+            ):
                 return "gpt4o"  # Fallback to GPT-4o
             return user_preference
-        
+
         # Auto-routing with plan restrictions
         if category in LLM_MODELS["claude"]["best_for"] and user_plan == "pro":
             return "claude"
-        
+
         return "gpt4o"  # Default to GPT-4o for free users
-    
+
     @staticmethod
     async def get_llm_response(
-        message: str, 
-        llm_choice: str, 
-        session_id: str, 
+        message: str,
+        llm_choice: str,
+        session_id: str,
         system_message: str,
-        conversation_history: List[dict] = None
+        conversation_history: List[dict] = None,
     ) -> tuple[str, float]:
         """Get response from specified LLM with fallback"""
-        
+
         try:
             if llm_choice == "claude":
-                return await LLMRouter._get_claude_response(message, session_id, system_message, conversation_history)
+                return await LLMRouter._get_claude_response(
+                    message, session_id, system_message, conversation_history
+                )
             elif llm_choice == "gpt4o":
-                return await LLMRouter._get_gpt4o_response(message, session_id, system_message, conversation_history)
+                return await LLMRouter._get_gpt4o_response(
+                    message, session_id, system_message, conversation_history
+                )
             else:
                 raise ValueError(f"Unknown LLM choice: {llm_choice}")
-                
+
         except Exception as e:
             logging.warning(f"Primary LLM ({llm_choice}) failed: {str(e)}")
             fallback_llm = "gpt4o" if llm_choice == "claude" else "claude"
             try:
                 if fallback_llm == "claude":
-                    return await LLMRouter._get_claude_response(message, session_id, system_message, conversation_history)
+                    return await LLMRouter._get_claude_response(
+                        message, session_id, system_message, conversation_history
+                    )
                 else:
-                    return await LLMRouter._get_gpt4o_response(message, session_id, system_message, conversation_history)
+                    return await LLMRouter._get_gpt4o_response(
+                        message, session_id, system_message, conversation_history
+                    )
             except Exception as fallback_error:
-                logging.error(f"Both LLMs failed. Claude: {str(e)}, GPT-4o: {str(fallback_error)}")
+                logging.error(
+                    f"Both LLMs failed. Claude: {str(e)}, GPT-4o: {str(fallback_error)}"
+                )
                 return generate_demo_response(message), 0.6
-    
+
     @staticmethod
-    async def _get_claude_response(message: str, session_id: str, system_message: str, conversation_history: List[dict] = None) -> tuple[str, float]:
+    async def _get_claude_response(
+        message: str,
+        session_id: str,
+        system_message: str,
+        conversation_history: List[dict] = None,
+    ) -> tuple[str, float]:
         """Get response from Claude"""
         context_message = message
         if conversation_history:
             context = format_conversation_context(conversation_history)
             context_message = context + f"\nUser's current message: {message}"
-        
-        chat = LlmChat(
-            api_key=ANTHROPIC_API_KEY,
-            session_id=session_id,
-            system_message=system_message
-        ).with_model("anthropic", "claude-sonnet-4-20250514").with_max_tokens(4096)
-        
+
+        chat = (
+            LlmChat(
+                api_key=ANTHROPIC_API_KEY,
+                session_id=session_id,
+                system_message=system_message,
+            )
+            .with_model("anthropic", "claude-sonnet-4-20250514")
+            .with_max_tokens(4096)
+        )
+
         user_message = UserMessage(text=context_message)
         response = await chat.send_message(user_message)
-        
+
         confidence = 0.9
         return response, confidence
-    
+
     @staticmethod
-    async def _get_gpt4o_response(message: str, session_id: str, system_message: str, conversation_history: List[dict] = None) -> tuple[str, float]:
+    async def _get_gpt4o_response(
+        message: str,
+        session_id: str,
+        system_message: str,
+        conversation_history: List[dict] = None,
+    ) -> tuple[str, float]:
         """Get response from GPT-4o"""
         context_message = message
         if conversation_history:
             context = format_conversation_context(conversation_history)
             context_message = context + f"\nUser's current message: {message}"
-        
-        chat = LlmChat(
-            api_key=OPENAI_API_KEY,
-            session_id=session_id,
-            system_message=system_message
-        ).with_model("openai", "gpt-4o").with_max_tokens(4096)
-        
+
+        chat = (
+            LlmChat(
+                api_key=OPENAI_API_KEY,
+                session_id=session_id,
+                system_message=system_message,
+            )
+            .with_model("openai", "gpt-4o")
+            .with_max_tokens(4096)
+        )
+
         user_message = UserMessage(text=context_message)
         response = await chat.send_message(user_message)
-        
+
         confidence = 0.85
         return response, confidence
 
-def get_system_message(category: str = "general", preferences: dict = None, advisor_style: str = "realist") -> str:
+
+def get_system_message(
+    category: str = "general", preferences: dict = None, advisor_style: str = "realist"
+) -> str:
     """Generate a tailored system message based on category, preferences, and enhanced advisor style"""
-    
+
     advisor_config = ADVISOR_STYLES.get(advisor_style, ADVISOR_STYLES["realist"])
-    
+
     base_prompt = f"""You are getgingee's {advisor_config['name']} Advisor, an AI-powered personal decision assistant.
 
 🎭 YOUR ADVISOR PERSONALITY:
@@ -1112,7 +1408,7 @@ Language Style: {advisor_config['language_style']}
 - Use encouraging language and action-oriented suggestions
 - Focus on potential benefits and success scenarios
 - End responses with motivational next steps"""
-    
+
     elif advisor_style == "skeptical":
         base_prompt += """
 - Thoroughly examine potential risks and downsides
@@ -1120,7 +1416,7 @@ Language Style: {advisor_config['language_style']}
 - Provide detailed caveats and considerations
 - Validate assumptions with evidence
 - Emphasize due diligence and careful planning"""
-    
+
     elif advisor_style == "creative":
         base_prompt += """
 - Use rich metaphors and imaginative language
@@ -1128,7 +1424,7 @@ Language Style: {advisor_config['language_style']}
 - Reframe problems from multiple creative angles
 - Think outside traditional decision frameworks
 - Inspire with innovative possibilities"""
-    
+
     elif advisor_style == "analytical":
         base_prompt += """
 - Use data, numbers, and quantifiable metrics
@@ -1136,7 +1432,7 @@ Language Style: {advisor_config['language_style']}
 - Provide step-by-step methodical analysis
 - Reference evidence and concrete facts
 - Create scoring matrices when appropriate"""
-    
+
     elif advisor_style == "intuitive":
         base_prompt += """
 - Trust and validate emotional responses
@@ -1144,7 +1440,7 @@ Language Style: {advisor_config['language_style']}
 - Consider how decisions align with values
 - Use warm, empathetic language
 - Focus on holistic well-being and fulfillment"""
-    
+
     elif advisor_style == "visionary":
         base_prompt += """
 - Think in terms of long-term impact and legacy
@@ -1152,7 +1448,7 @@ Language Style: {advisor_config['language_style']}
 - Consider strategic implications and transformative potential
 - Use inspiring, forward-thinking language
 - Challenge conventional thinking with big-picture perspective"""
-    
+
     elif advisor_style == "supportive":
         base_prompt += """
 - Provide emotional validation and encouragement
@@ -1160,7 +1456,7 @@ Language Style: {advisor_config['language_style']}
 - Use gentle, understanding language
 - Focus on emotional well-being throughout the process
 - Build confidence while providing guidance"""
-    
+
     else:  # realist
         base_prompt += """
 - Provide balanced, objective analysis
@@ -1184,64 +1480,77 @@ Important: This is a continuing conversation. Reference previous messages and bu
     if category and category != "general":
         category_context = DECISION_CATEGORIES.get(category, "")
         base_prompt += f"\n\n🎯 DECISION CATEGORY: You are helping with {category} decisions. Focus on: {category_context}"
-    
+
     if preferences:
         pref_text = ", ".join([f"{k}: {v}" for k, v in preferences.items() if v])
-        base_prompt += f"\n\n🎯 USER PREFERENCES: Consider these preferences: {pref_text}"
-    
+        base_prompt += (
+            f"\n\n🎯 USER PREFERENCES: Consider these preferences: {pref_text}"
+        )
+
     base_prompt += f"\n\nMaintain your {advisor_config['name']} personality while being helpful and building user confidence in their decision-making process."
-    
+
     return base_prompt
+
 
 def format_conversation_context(conversations: List[dict]) -> str:
     """Format conversation history for LLM context"""
     if not conversations:
         return ""
-    
+
     context = "\n\nPrevious conversation context:\n"
     for conv in conversations[-5:]:
         context += f"User: {conv['user_message']}\n"
         context += f"Assistant: {conv['ai_response']}\n\n"
-    
-    context += "Continue this conversation, building upon the information already provided.\n"
+
+    context += (
+        "Continue this conversation, building upon the information already provided.\n"
+    )
     return context
 
+
 @api_router.post("/chat", response_model=DecisionResponse)
-async def chat_with_assistant(request: DecisionRequest, current_user: dict = Depends(get_current_user)):
+async def chat_with_assistant(
+    request: DecisionRequest, current_user: dict = Depends(get_current_user)
+):
     """Main chat endpoint with monetization and feature gating"""
     try:
         # Security: Sanitize user input
         request.message = security_service.sanitize_input(request.message)
-        
+
         # Check permissions and usage
         permission_check = await check_usage_and_permissions(
-            current_user, 
-            request.use_voice, 
-            request.advisor_style, 
-            request.llm_preference
+            current_user,
+            request.use_voice,
+            request.advisor_style,
+            request.llm_preference,
         )
-        
+
         if not permission_check["allowed"]:
             raise HTTPException(
-                status.HTTP_403_FORBIDDEN, 
-                {"errors": permission_check["errors"], "credit_cost": permission_check["credit_cost"]}
+                status.HTTP_403_FORBIDDEN,
+                {
+                    "errors": permission_check["errors"],
+                    "credit_cost": permission_check["credit_cost"],
+                },
             )
-        
+
         credit_cost = permission_check["credit_cost"]
         decision_id = request.decision_id or str(uuid.uuid4())
-        
+
         # Get or create decision session
-        existing_session = await db.decision_sessions.find_one({"decision_id": decision_id, "user_id": current_user["id"]})
+        existing_session = await db.decision_sessions.find_one(
+            {"decision_id": decision_id, "user_id": current_user["id"]}
+        )
         if not existing_session:
             title = generate_decision_title(request.message, request.category)
             session_obj = DecisionSession(
                 decision_id=decision_id,
-                user_id=current_user["id"], 
+                user_id=current_user["id"],
                 title=title,
                 category=request.category or "general",
                 user_preferences=request.preferences or {},
                 llm_preference=request.llm_preference,
-                advisor_style=request.advisor_style
+                advisor_style=request.advisor_style,
             )
             await db.decision_sessions.insert_one(session_obj.dict())
         else:
@@ -1250,48 +1559,72 @@ async def chat_with_assistant(request: DecisionRequest, current_user: dict = Dep
                 "message_count": existing_session.get("message_count", 0) + 1,
                 "llm_preference": request.llm_preference,
                 "advisor_style": request.advisor_style,
-                "total_credits_used": existing_session.get("total_credits_used", 0) + credit_cost
+                "total_credits_used": existing_session.get("total_credits_used", 0)
+                + credit_cost,
             }
             if request.preferences:
-                update_data["user_preferences"] = {**existing_session.get("user_preferences", {}), **request.preferences}
-            
+                update_data["user_preferences"] = {
+                    **existing_session.get("user_preferences", {}),
+                    **request.preferences,
+                }
+
             await db.decision_sessions.update_one(
                 {"decision_id": decision_id, "user_id": current_user["id"]},
-                {"$set": update_data}
+                {"$set": update_data},
             )
-        
+
         # Get conversation history
-        conversation_history = await db.conversations.find(
+        conversation_history = (
+            await db.conversations.find(
+                {"decision_id": decision_id, "user_id": current_user["id"]}
+            )
+            .sort("timestamp", 1)
+            .to_list(20)
+        )
+
+        session_data = await db.decision_sessions.find_one(
             {"decision_id": decision_id, "user_id": current_user["id"]}
-        ).sort("timestamp", 1).to_list(20)
-        
-        session_data = await db.decision_sessions.find_one({"decision_id": decision_id, "user_id": current_user["id"]})
-        user_preferences = session_data.get("user_preferences", {}) if session_data else {}
-        category = session_data.get("category", "general") if session_data else (request.category or "general")
-        advisor_style = session_data.get("advisor_style", "realist") if session_data else request.advisor_style
-        
+        )
+        user_preferences = (
+            session_data.get("user_preferences", {}) if session_data else {}
+        )
+        category = (
+            session_data.get("category", "general")
+            if session_data
+            else (request.category or "general")
+        )
+        advisor_style = (
+            session_data.get("advisor_style", "realist")
+            if session_data
+            else request.advisor_style
+        )
+
         # Determine LLM with plan restrictions
         llm_choice = LLMRouter.determine_best_llm(
-            category, 
-            request.message, 
-            request.llm_preference, 
-            current_user.get("plan", "free")
+            category,
+            request.message,
+            request.llm_preference,
+            current_user.get("plan", "free"),
         )
-        
+
         system_message = get_system_message(category, user_preferences, advisor_style)
-        
+
         # Get AI response
         ai_response, confidence = await LLMRouter.get_llm_response(
-            request.message, 
-            llm_choice, 
-            decision_id, 
-            system_message, 
-            conversation_history
+            request.message,
+            llm_choice,
+            decision_id,
+            system_message,
+            conversation_history,
         )
-        
-        reasoning_type = determine_reasoning_type(request.message, category, advisor_style)
-        advisor_personality = ADVISOR_STYLES.get(advisor_style, ADVISOR_STYLES["realist"])
-        
+
+        reasoning_type = determine_reasoning_type(
+            request.message, category, advisor_style
+        )
+        advisor_personality = ADVISOR_STYLES.get(
+            advisor_style, ADVISOR_STYLES["realist"]
+        )
+
         # Deduct credits and update usage
         plan = current_user.get("plan", "free")
         if plan == "free":
@@ -1299,17 +1632,15 @@ async def chat_with_assistant(request: DecisionRequest, current_user: dict = Dep
             if monthly_used < SUBSCRIPTION_PLANS["free"]["monthly_decisions"]:
                 # Use free decision
                 await db.users.update_one(
-                    {"id": current_user["id"]},
-                    {"$inc": {"monthly_decisions_used": 1}}
+                    {"id": current_user["id"]}, {"$inc": {"monthly_decisions_used": 1}}
                 )
             else:
                 # Use credits
                 await db.users.update_one(
-                    {"id": current_user["id"]},
-                    {"$inc": {"credits": -credit_cost}}
+                    {"id": current_user["id"]}, {"$inc": {"credits": -credit_cost}}
                 )
         # Pro users don't have limits, so no deduction needed
-        
+
         # Store conversation
         conversation = ConversationHistory(
             decision_id=decision_id,
@@ -1321,10 +1652,10 @@ async def chat_with_assistant(request: DecisionRequest, current_user: dict = Dep
             llm_used=llm_choice,
             advisor_style=advisor_style,
             advisor_personality=advisor_personality,
-            credits_used=credit_cost
+            credits_used=credit_cost,
         )
         await db.conversations.insert_one(conversation.dict())
-        
+
         return DecisionResponse(
             decision_id=decision_id,
             response=ai_response,
@@ -1333,14 +1664,17 @@ async def chat_with_assistant(request: DecisionRequest, current_user: dict = Dep
             confidence_score=confidence,
             reasoning_type=reasoning_type,
             advisor_personality=advisor_personality,
-            credits_used=credit_cost
+            credits_used=credit_cost,
         )
-        
+
     except HTTPException:
         raise
     except Exception as e:
         logging.error(f"Error in chat endpoint: {str(e)}")
-        raise HTTPException(status.HTTP_500_INTERNAL_SERVER_ERROR, f"Error processing request: {str(e)}")
+        raise HTTPException(
+            status.HTTP_500_INTERNAL_SERVER_ERROR, f"Error processing request: {str(e)}"
+        )
+
 
 # GDPR Compliance Endpoints
 @api_router.get("/auth/export-data")
@@ -1348,7 +1682,7 @@ async def export_user_data(current_user: dict = Depends(get_current_user)):
     """Export all user data for GDPR compliance"""
     try:
         user_id = current_user["id"]
-        
+
         # Gather all user data
         user_data = {
             "personal_information": {
@@ -1358,111 +1692,125 @@ async def export_user_data(current_user: dict = Depends(get_current_user)):
                 "plan": current_user["plan"],
                 "created_at": current_user["created_at"],
                 "last_login": current_user.get("last_login"),
-                "email_verified": current_user.get("email_verified", False)
+                "email_verified": current_user.get("email_verified", False),
             },
             "usage_data": {
                 "monthly_decisions_used": current_user.get("monthly_decisions_used", 0),
                 "credits": current_user.get("credits", 0),
-                "subscription_expires": current_user.get("subscription_expires")
-            }
+                "subscription_expires": current_user.get("subscription_expires"),
+            },
         }
-        
+
         # Get decision sessions
         decision_sessions = []
         async for session in db.decision_sessions_new.find({"user_id": user_id}):
             session["_id"] = str(session["_id"])  # Convert ObjectId to string
             decision_sessions.append(session)
-        
+
         user_data["decision_sessions"] = decision_sessions
-        
+
         # Get conversation history
         conversations = []
         async for conversation in db.conversation_history.find({"user_id": user_id}):
             conversation["_id"] = str(conversation["_id"])
             conversations.append(conversation)
-        
+
         user_data["conversation_history"] = conversations
-        
+
         # Return as downloadable JSON
         return {
             "message": "User data export completed",
             "export_date": datetime.utcnow().isoformat(),
-            "data": user_data
+            "data": user_data,
         }
-        
+
     except Exception as e:
         logging.error(f"Error exporting user data: {str(e)}")
-        raise HTTPException(status.HTTP_500_INTERNAL_SERVER_ERROR, "Error exporting user data")
+        raise HTTPException(
+            status.HTTP_500_INTERNAL_SERVER_ERROR, "Error exporting user data"
+        )
+
 
 @api_router.delete("/auth/delete-account")
 async def delete_user_account(current_user: dict = Depends(get_current_user)):
     """Delete user account and all associated data for GDPR compliance"""
     try:
         user_id = current_user["id"]
-        
+
         # Delete user data from all collections
         await db.users.delete_one({"id": user_id})
         await db.decision_sessions_new.delete_many({"user_id": user_id})
         await db.conversation_history.delete_many({"user_id": user_id})
         await db.decision_sessions.delete_many({"user_id": user_id})  # Old format
-        
+
         # Log the deletion for audit purposes
-        logging.info(f"Account deleted for user: {current_user['email']} (ID: {user_id})")
-        
+        logging.info(
+            f"Account deleted for user: {current_user['email']} (ID: {user_id})"
+        )
+
         return {
             "message": "Account and all associated data have been permanently deleted",
             "deleted_at": datetime.utcnow().isoformat(),
-            "user_id": user_id
+            "user_id": user_id,
         }
-        
+
     except Exception as e:
         logging.error(f"Error deleting user account: {str(e)}")
-        raise HTTPException(status.HTTP_500_INTERNAL_SERVER_ERROR, "Error deleting account")
+        raise HTTPException(
+            status.HTTP_500_INTERNAL_SERVER_ERROR, "Error deleting account"
+        )
+
 
 def determine_reasoning_type(message: str, category: str, advisor_style: str) -> str:
     """Determine the type of reasoning being used based on message, category, and advisor style"""
     message_lower = message.lower()
-    
+
     advisor_reasoning = {
         "optimistic": "Opportunity-Focused Analysis",
-        "skeptical": "Risk Assessment & Mitigation", 
+        "skeptical": "Risk Assessment & Mitigation",
         "creative": "Creative Exploration & Reframing",
         "analytical": "Quantitative Decision Matrix",
         "intuitive": "Gut Check & Alignment Analysis",
         "visionary": "Strategic Future Mapping",
         "supportive": "Emotional Alignment & Well-being",
-        "realist": "Weighted Pros/Cons Analysis"
+        "realist": "Weighted Pros/Cons Analysis",
     }
-    
+
     base_reasoning = advisor_reasoning.get(advisor_style, "General Decision Analysis")
-    
-    if any(word in message_lower for word in ["compare", "vs", "versus", "better", "worse"]):
+
+    if any(
+        word in message_lower for word in ["compare", "vs", "versus", "better", "worse"]
+    ):
         return f"{base_reasoning} - Comparative"
-    elif any(word in message_lower for word in ["budget", "cost", "price", "money", "afford"]):
+    elif any(
+        word in message_lower for word in ["budget", "cost", "price", "money", "afford"]
+    ):
         return f"{base_reasoning} - Financial"
     elif any(word in message_lower for word in ["step", "process", "how to", "guide"]):
         return f"{base_reasoning} - Process-Oriented"
-    
+
     return base_reasoning
+
 
 def generate_decision_title(message: str, category: str = None) -> str:
     """Generate a user-friendly title for a decision based on the first message"""
     words = message.split()[:8]
     title = " ".join(words)
-    
+
     if len(title) > 60:
         title = title[:57] + "..."
-    
+
     if category and category != "general":
         title = f"[{category.title()}] {title}"
-    
+
     return title
+
 
 @api_router.get("/advisor-styles")
 async def get_advisor_styles(current_user: dict = Depends(get_current_user)):
     """Get available advisor styles based on user's plan"""
     user_plan = current_user.get("plan", "free")
-    
+
     available_styles = {}
     for key, style in ADVISOR_STYLES.items():
         if not style.get("pro_only", False) or user_plan == "pro":
@@ -1472,41 +1820,45 @@ async def get_advisor_styles(current_user: dict = Depends(get_current_user)):
             restricted_style = style.copy()
             restricted_style["locked"] = True
             available_styles[key] = restricted_style
-    
+
     return {"advisor_styles": available_styles, "user_plan": user_plan}
+
 
 # New structured decision flow endpoint
 @api_router.post("/decision/step", response_model=DecisionStepResponse)
-async def process_decision_step(request: DecisionStepRequest, current_user: dict = Depends(get_current_user)):
+async def process_decision_step(
+    request: DecisionStepRequest, current_user: dict = Depends(get_current_user)
+):
     """Process a step in the structured decision flow"""
     try:
         decision_id = request.decision_id or str(uuid.uuid4())
-        
+
         # Get or create decision session
-        session = await db.decision_sessions_new.find_one({
-            "id": decision_id,
-            "user_id": current_user["id"] if current_user else None
-        })
-        
+        session = await db.decision_sessions_new.find_one(
+            {"id": decision_id, "user_id": current_user["id"] if current_user else None}
+        )
+
         if not session and request.step == "initial":
             # Create new session
             session_obj = DecisionSessionNew(
                 id=decision_id,
                 user_id=current_user["id"] if current_user else None,
                 initial_question=request.message,
-                category=auto_classify_question(request.message)
+                category=auto_classify_question(request.message),
             )
             await db.decision_sessions_new.insert_one(session_obj.dict())
             session = session_obj.dict()
-        
+
         if not session:
             raise HTTPException(status.HTTP_404_NOT_FOUND, "Decision session not found")
-        
+
         # Process based on step
         if request.step == "initial":
             # Generate first follow-up question
-            followup = await generate_followup_question(request.message, 1, session.get("category"))
-            
+            followup = await generate_followup_question(
+                request.message, 1, session.get("category")
+            )
+
             # Update session
             await db.decision_sessions_new.update_one(
                 {"id": decision_id},
@@ -1514,65 +1866,67 @@ async def process_decision_step(request: DecisionStepRequest, current_user: dict
                     "$set": {
                         "current_step": "followup",
                         "step_number": 1,
-                        "last_active": datetime.utcnow()
+                        "last_active": datetime.utcnow(),
                     },
-                    "$push": {"followup_questions": followup.dict()}
-                }
+                    "$push": {"followup_questions": followup.dict()},
+                },
             )
-            
+
             return DecisionStepResponse(
                 decision_id=decision_id,
                 step="followup",
                 step_number=1,
                 response="Let me ask you a few questions to give you the best recommendation.",
-                followup_question=followup
+                followup_question=followup,
             )
-        
+
         elif request.step == "followup":
-            step_num = request.step_number or len(session.get("followup_answers", [])) + 1
-            
+            step_num = (
+                request.step_number or len(session.get("followup_answers", [])) + 1
+            )
+
             # Store the answer
             await db.decision_sessions_new.update_one(
                 {"id": decision_id},
                 {
                     "$push": {"followup_answers": request.message},
-                    "$set": {"last_active": datetime.utcnow()}
-                }
+                    "$set": {"last_active": datetime.utcnow()},
+                },
             )
-            
+
             # Check if we need more questions (max 3)
             if step_num < 3:
                 # Generate next follow-up question
                 followup = await generate_followup_question(
-                    session["initial_question"], 
-                    step_num + 1, 
+                    session["initial_question"],
+                    step_num + 1,
                     session.get("category"),
-                    session.get("followup_answers", []) + [request.message]
+                    session.get("followup_answers", []) + [request.message],
                 )
-                
+
                 await db.decision_sessions_new.update_one(
                     {"id": decision_id},
                     {
                         "$push": {"followup_questions": followup.dict()},
-                        "$set": {"step_number": step_num + 1}
-                    }
+                        "$set": {"step_number": step_num + 1},
+                    },
                 )
-                
+
                 return DecisionStepResponse(
                     decision_id=decision_id,
                     step="followup",
                     step_number=step_num + 1,
                     response="Thank you for that information.",
-                    followup_question=followup
+                    followup_question=followup,
                 )
             else:
                 # Generate final recommendation
                 recommendation = await generate_final_recommendation(
                     session["initial_question"],
                     session.get("followup_answers", []) + [request.message],
-                    session.get("category")
+                    session.get("category"),
                 )
-                
+
                 await db.decision_sessions_new.update_one(
                     {"id": decision_id},
                     {
@@ -1580,57 +1934,59 @@ async def process_decision_step(request: DecisionStepRequest, current_user: dict
                             "current_step": "complete",
                             "recommendation": recommendation.dict(),
                             "completed_at": datetime.utcnow(),
-                            "last_active": datetime.utcnow()
+                            "last_active": datetime.utcnow(),
                         }
-                    }
+                    },
                 )
-                
+
                 return DecisionStepResponse(
                     decision_id=decision_id,
                     step="complete",
                     step_number=step_num,
                     response="Based on our conversation, here's my recommendation:",
                     is_complete=True,
-                    recommendation=recommendation
+                    recommendation=recommendation,
                 )
-        
+
         elif request.step == "adjust":
             # Handle adjustment - regenerate recommendation
             await db.decision_sessions_new.update_one(
                 {"id": decision_id},
                 {
                     "$inc": {"adjustment_count": 1},
-                    "$set": {"last_active": datetime.utcnow()}
-                }
+                    "$set": {"last_active": datetime.utcnow()},
+                },
             )
-            
+
             # Regenerate recommendation with adjustment context
             recommendation = await generate_final_recommendation(
                 session["initial_question"],
                 session.get("followup_answers", []),
                 session.get("category"),
-                adjustment_context=request.message
+                adjustment_context=request.message,
             )
-            
+
             await db.decision_sessions_new.update_one(
-                {"id": decision_id},
-                {"$set": {"recommendation": recommendation.dict()}}
+                {"id": decision_id}, {"$set": {"recommendation": recommendation.dict()}}
             )
-            
+
             return DecisionStepResponse(
                 decision_id=decision_id,
                 step="complete",
                 step_number=session.get("step_number", 3),
                 response="I've adjusted my recommendation based on your feedback:",
                 is_complete=True,
-                recommendation=recommendation
+                recommendation=recommendation,
             )
-        
+
     except HTTPException:
         raise
     except Exception as e:
         logging.error(f"Error in decision step: {str(e)}")
-        raise HTTPException(status.HTTP_500_INTERNAL_SERVER_ERROR, f"Error processing request: {str(e)}")
+        raise HTTPException(
+            status.HTTP_500_INTERNAL_SERVER_ERROR, f"Error processing request: {str(e)}"
+        )
+
 
 # Anonymous decision flow (no auth required)
 @api_router.post("/decision/step/anonymous", response_model=DecisionStepResponse)
@@ -1638,96 +1994,100 @@ async def process_anonymous_decision_step(request: DecisionStepRequest):
     """Process a step in the structured decision flow for anonymous users"""
     try:
         decision_id = request.decision_id or str(uuid.uuid4())
-        
+
         # Get or create decision session
         session = await db.decision_sessions_new.find_one({"id": decision_id})
-        
+
         if not session and request.step == "initial":
             # Create new session
             session_obj = DecisionSessionNew(
                 id=decision_id,
                 user_id=None,  # Anonymous
                 initial_question=request.message,
-                category=auto_classify_question(request.message)
+                category=auto_classify_question(request.message),
             )
             await db.decision_sessions_new.insert_one(session_obj.dict())
             session = session_obj.dict()
-        
+
         if not session:
             raise HTTPException(status.HTTP_404_NOT_FOUND, "Decision session not found")
-        
+
         # Same processing logic as authenticated flow
         # (This allows anonymous users to get full decision assistance)
-        
+
         if request.step == "initial":
-            followup = await generate_followup_question(request.message, 1, session.get("category"))
-            
+            followup = await generate_followup_question(
+                request.message, 1, session.get("category")
+            )
+
             await db.decision_sessions_new.update_one(
                 {"id": decision_id},
                 {
                     "$set": {
                         "current_step": "followup",
                         "step_number": 1,
-                        "last_active": datetime.utcnow()
+                        "last_active": datetime.utcnow(),
                     },
-                    "$push": {"followup_questions": followup.dict()}
-                }
+                    "$push": {"followup_questions": followup.dict()},
+                },
             )
-            
+
             return DecisionStepResponse(
                 decision_id=decision_id,
                 step="followup",
                 step_number=1,
                 response="Let me ask you a few questions to give you the best recommendation.",
-                followup_question=followup
+                followup_question=followup,
             )
-        
+
         # Continue with same logic as authenticated endpoint...
         elif request.step == "followup":
-            step_num = request.step_number or len(session.get("followup_answers", [])) + 1
-            
+            step_num = (
+                request.step_number or len(session.get("followup_answers", [])) + 1
+            )
+
             # Store the answer
             await db.decision_sessions_new.update_one(
                 {"id": decision_id},
                 {
                     "$push": {"followup_answers": request.message},
-                    "$set": {"last_active": datetime.utcnow()}
-                }
+                    "$set": {"last_active": datetime.utcnow()},
+                },
             )
-            
+
             # Check if we need more questions (max 3)
             if step_num < 3:
                 # Generate next follow-up question
                 followup = await generate_followup_question(
-                    session["initial_question"], 
-                    step_num + 1, 
+                    session["initial_question"],
+                    step_num + 1,
                     session.get("category"),
-                    session.get("followup_answers", []) + [request.message]
+                    session.get("followup_answers", []) + [request.message],
                 )
-                
+
                 await db.decision_sessions_new.update_one(
                     {"id": decision_id},
                     {
                         "$push": {"followup_questions": followup.dict()},
-                        "$set": {"step_number": step_num + 1}
-                    }
+                        "$set": {"step_number": step_num + 1},
+                    },
                 )
-                
+
                 return DecisionStepResponse(
                     decision_id=decision_id,
                     step="followup",
                     step_number=step_num + 1,
                     response="Thank you for that information.",
-                    followup_question=followup
+                    followup_question=followup,
                 )
             else:
                 # Generate final recommendation
                 recommendation = await generate_final_recommendation(
                     session["initial_question"],
                     session.get("followup_answers", []) + [request.message],
-                    session.get("category")
+                    session.get("category"),
                 )
-                
+
                 await db.decision_sessions_new.update_one(
                     {"id": decision_id},
                     {
@@ -1735,20 +2095,20 @@ async def process_anonymous_decision_step(request: DecisionStepRequest):
                             "current_step": "complete",
                             "recommendation": recommendation.dict(),
                             "completed_at": datetime.utcnow(),
-                            "last_active": datetime.utcnow()
+                            "last_active": datetime.utcnow(),
                         }
-                    }
+                    },
                 )
-                
+
                 return DecisionStepResponse(
                     decision_id=decision_id,
                     step="complete",
                     step_number=step_num,
                     response="Based on our conversation, here's my recommendation:",
                     is_complete=True,
-                    recommendation=recommendation
+                    recommendation=recommendation,
                 )
-        
+
         # Handle adjustment step
         elif request.step == "adjust":
             # Handle adjustment - regenerate recommendation
@@ -1756,69 +2116,98 @@ async def process_anonymous_decision_step(request: DecisionStepRequest):
                 {"id": decision_id},
                 {
                     "$inc": {"adjustment_count": 1},
-                    "$set": {"last_active": datetime.utcnow()}
-                }
+                    "$set": {"last_active": datetime.utcnow()},
+                },
             )
-            
+
             # Regenerate recommendation with adjustment context
             recommendation = await generate_final_recommendation(
                 session["initial_question"],
                 session.get("followup_answers", []),
                 session.get("category"),
-                adjustment_context=request.message
+                adjustment_context=request.message,
             )
-            
+
             await db.decision_sessions_new.update_one(
-                {"id": decision_id},
-                {"$set": {"recommendation": recommendation.dict()}}
+                {"id": decision_id}, {"$set": {"recommendation": recommendation.dict()}}
             )
-            
+
             return DecisionStepResponse(
                 decision_id=decision_id,
                 step="complete",
                 step_number=session.get("step_number", 3),
                 response="I've adjusted my recommendation based on your feedback:",
                 is_complete=True,
-                recommendation=recommendation
+                recommendation=recommendation,
             )
-        
+
     except HTTPException:
         raise
     except Exception as e:
         logging.error(f"Error in anonymous decision step: {str(e)}")
-        raise HTTPException(status.HTTP_500_INTERNAL_SERVER_ERROR, f"Error processing request: {str(e)}")
+        raise HTTPException(
+            status.HTTP_500_INTERNAL_SERVER_ERROR, f"Error processing request: {str(e)}"
+        )
+
 
 # Helper functions for the new decision flow
 def auto_classify_question(question: str) -> str:
     """Auto-classify the decision question into a category"""
     question_lower = question.lower()
-    
+
     # Simple keyword-based classification
-    if any(word in question_lower for word in ["buy", "purchase", "product", "brand", "choice"]):
+    if any(
+        word in question_lower
+        for word in ["buy", "purchase", "product", "brand", "choice"]
+    ):
         return "consumer"
-    elif any(word in question_lower for word in ["travel", "trip", "vacation", "visit", "destination"]):
+    elif any(
+        word in question_lower
+        for word in ["travel", "trip", "vacation", "visit", "destination"]
+    ):
         return "travel"
-    elif any(word in question_lower for word in ["job", "career", "work", "position", "company"]):
+    elif any(
+        word in question_lower
+        for word in ["job", "career", "work", "position", "company"]
+    ):
         return "career"
-    elif any(word in question_lower for word in ["study", "school", "course", "education", "learn"]):
+    elif any(
+        word in question_lower
+        for word in ["study", "school", "course", "education", "learn"]
+    ):
         return "education"
-    elif any(word in question_lower for word in ["health", "exercise", "diet", "lifestyle", "fitness"]):
+    elif any(
+        word in question_lower
+        for word in ["health", "exercise", "diet", "lifestyle", "fitness"]
+    ):
         return "lifestyle"
-    elif any(word in question_lower for word in ["movie", "book", "game", "entertainment", "watch"]):
+    elif any(
+        word in question_lower
+        for word in ["movie", "book", "game", "entertainment", "watch"]
+    ):
         return "entertainment"
-    elif any(word in question_lower for word in ["money", "invest", "financial", "budget", "save"]):
+    elif any(
+        word in question_lower
+        for word in ["money", "invest", "financial", "budget", "save"]
+    ):
         return "financial"
     else:
         return "general"
 
-async def generate_followup_question(initial_question: str, step_number: int, category: str = "general", previous_answers: List[str] = None) -> DecisionFollowUpQuestion:
+
+async def generate_followup_question(
+    initial_question: str,
+    step_number: int,
+    category: str = "general",
+    previous_answers: List[str] = None,
+) -> DecisionFollowUpQuestion:
     """Generate a relevant follow-up question using AI"""
-    
+
     # Build context for AI
     context = f"Initial question: {initial_question}\nCategory: {category}\nStep: {step_number}/3"
     if previous_answers:
         context += f"\nPrevious answers: {', '.join(previous_answers)}"
-    
+
     # System prompt for generating follow-up questions
     system_prompt = """You are an expert decision advisor. Your job is to ask insightful follow-up questions that help users make better decisions.
 
@@ -1835,76 +2224,82 @@ Rules:
 Return only the question, nothing else."""
 
     message = f"User's situation: {context}\n\nGenerate the next follow-up question:"
-    
+
     try:
         # Use the LLM Router to get AI response - using the correct signature
         response, confidence = await LLMRouter.get_llm_response(
-            message, 
-            "gpt4o", 
-            f"followup_{step_number}_{category}", 
+            message,
+            "gpt4o",
+            f"followup_{step_number}_{category}",
             system_prompt,
-            []  # Empty conversation history for followup questions
+            [],  # Empty conversation history for followup questions
         )
-        
+
         # Clean up the response
         question = response.strip().strip('"').strip("'")
-        if not question.endswith('?'):
-            question += '?'
-            
+        if not question.endswith("?"):
+            question += "?"
+
         return DecisionFollowUpQuestion(
-            question=question,
-            step_number=step_number,
-            context=context
+            question=question, step_number=step_number, context=context
         )
-        
+
     except Exception as e:
         logger.error(f"Error generating AI follow-up question: {e}")
         # Fallback to template questions
         questions_by_category = {
             "consumer": [
                 "What's your budget range for this purchase?",
-                "What features or qualities are most important to you?", 
-                "When do you need to make this decision?"
+                "What features or qualities are most important to you?",
+                "When do you need to make this decision?",
             ],
             "travel": [
                 "What's your budget for this trip?",
                 "What type of experience are you looking for?",
-                "How long do you have available?"
+                "How long do you have available?",
             ],
             "career": [
                 "What are your main career goals?",
                 "What factors are most important to you in a job?",
-                "What's your timeline for making this change?"
+                "What's your timeline for making this change?",
             ],
             "general": [
                 "What factors are most important to you in this decision?",
                 "What are your main concerns or constraints?",
-                "What would success look like to you?"
-            ]
+                "What would success look like to you?",
+            ],
         }
-        
-        category_questions = questions_by_category.get(category, questions_by_category["general"])
+
+        category_questions = questions_by_category.get(
+            category, questions_by_category["general"]
+        )
         question_index = min(step_number - 1, len(category_questions) - 1)
-        
+
         return DecisionFollowUpQuestion(
             question=category_questions[question_index],
             step_number=step_number,
-            context=context
+            context=context,
         )
 
-async def generate_final_recommendation(initial_question: str, answers: List[str], category: str = "general", adjustment_context: str = None) -> DecisionRecommendation:
+
+async def generate_final_recommendation(
+    initial_question: str,
+    answers: List[str],
+    category: str = "general",
+    adjustment_context: str = None,
+) -> DecisionRecommendation:
     """Generate final recommendation using AI"""
-    
+
     # Build comprehensive context
     context = f"""
 Decision Question: {initial_question}
 Category: {category}
 User Responses: {', '.join(answers) if answers else 'None'}
 """
-    
+
     if adjustment_context:
         context += f"\nAdjustment Request: {adjustment_context}"
-    
+
     # System prompt for generating recommendations
     system_prompt = """You are an expert decision advisor. Based on the user's question and their responses to follow-up questions, provide a clear, actionable recommendation.
 
@@ -1926,8 +2321,10 @@ RECOMMENDATION: Based on your budget and timeline, I recommend choosing Option A
 REASONING: This choice aligns with your stated budget constraints while delivering the features you identified as most important.
 CONFIDENCE: 85"""
 
-    message = f"Please analyze this decision and provide your recommendation:\n\n{context}"
-    
+    message = (
+        f"Please analyze this decision and provide your recommendation:\n\n{context}"
+    )
+
     try:
         # Use the LLM Router to get AI response - using the correct signature
         response, ai_confidence = await LLMRouter.get_llm_response(
@@ -1935,76 +2332,81 @@ CONFIDENCE: 85"""
             llm_choice="gpt4o",
             session_id=f"recommendation_{hash(initial_question)}",
             system_message=system_prompt,
-            conversation_history=[]
+            conversation_history=[],
         )
-        
+
         # Parse the structured response
         recommendation_text = ""
         reasoning_text = ""
         confidence_score = 75  # Default
-        
-        lines = response.split('\n')
+
+        lines = response.split("\n")
         current_section = None
-        
+
         for line in lines:
             line = line.strip()
-            if line.startswith('RECOMMENDATION:'):
-                current_section = 'recommendation'
-                recommendation_text = line.replace('RECOMMENDATION:', '').strip()
-            elif line.startswith('REASONING:'):
-                current_section = 'reasoning'
-                reasoning_text = line.replace('REASONING:', '').strip()
-            elif line.startswith('CONFIDENCE:'):
-                current_section = 'confidence'
-                conf_text = line.replace('CONFIDENCE:', '').strip()
+            if line.startswith("RECOMMENDATION:"):
+                current_section = "recommendation"
+                recommendation_text = line.replace("RECOMMENDATION:", "").strip()
+            elif line.startswith("REASONING:"):
+                current_section = "reasoning"
+                reasoning_text = line.replace("REASONING:", "").strip()
+            elif line.startswith("CONFIDENCE:"):
+                current_section = "confidence"
+                conf_text = line.replace("CONFIDENCE:", "").strip()
                 try:
-                    confidence_score = int(''.join(filter(str.isdigit, conf_text)))
-                    confidence_score = max(1, min(100, confidence_score))  # Clamp to 1-100
+                    confidence_score = int("".join(filter(str.isdigit, conf_text)))
+                    confidence_score = max(
+                        1, min(100, confidence_score)
+                    )  # Clamp to 1-100
                 except:
                     confidence_score = 75
             elif current_section and line:
-                if current_section == 'recommendation':
+                if current_section == "recommendation":
                     recommendation_text += " " + line
-                elif current_section == 'reasoning':
+                elif current_section == "reasoning":
                     reasoning_text += " " + line
-        
+
         # Fallback if parsing failed
         if not recommendation_text:
-            recommendation_text = response[:200] + "..." if len(response) > 200 else response
+            recommendation_text = (
+                response[:200] + "..." if len(response) > 200 else response
+            )
         if not reasoning_text:
             reasoning_text = "This recommendation is based on the information you provided and common best practices for this type of decision."
-            
+
         return DecisionRecommendation(
             recommendation=recommendation_text.strip(),
             confidence_score=float(confidence_score),
             reasoning=reasoning_text.strip(),
-            action_link=None
+            action_link=None,
         )
-        
+
     except Exception as e:
         logger.error(f"Error generating AI recommendation: {e}")
         # Fallback to template recommendation
         recommendation_text = f"Based on your question about {initial_question.lower()}"
         if answers:
             recommendation_text += f" and considering your preferences, I recommend taking time to evaluate your options carefully."
-        
+
         confidence = 70 + len(answers) * 5
         confidence = min(confidence, 90)
-        
+
         reasoning = f"This recommendation considers the {len(answers)} responses you provided and focuses on practical next steps for {category} decisions."
-        
+
         return DecisionRecommendation(
             recommendation=recommendation_text,
             confidence_score=confidence,
             reasoning=reasoning,
-            action_link=None
+            action_link=None,
         )
+
 
 # Advanced Decision Flow with AI Orchestration
 @api_router.post("/decision/advanced", response_model=AdvancedDecisionStepResponse)
 async def process_advanced_decision_step(
     request: AdvancedDecisionStepRequest,
-    current_user: dict = Depends(get_current_user_optional)
+    current_user: dict = Depends(get_current_user_optional),
 ):
     """
     Advanced decision processing with multi-LLM orchestration
@@ -2012,24 +2414,23 @@ async def process_advanced_decision_step(
     """
     if not AI_ORCHESTRATOR_AVAILABLE:
         raise HTTPException(
-            status_code=503, 
-            detail="Advanced AI orchestration not available"
+            status_code=503, detail="Advanced AI orchestration not available"
         )
-        
+
     try:
         user_id = current_user.get("id") if current_user else None
         decision_id = request.decision_id or str(uuid.uuid4())
-        
+
         # Get or create decision session
         session = await db.decision_sessions_advanced.find_one({"id": decision_id})
-        
+
         if not session and request.step == "initial":
             # Use smart classification and routing
             smart_classification = await ai_orchestrator.smart_classify_and_route(
-                request.message, 
-                current_user.get("plan", "free") if current_user else "free"
+                request.message,
+                current_user.get("plan", "free") if current_user else "free",
             )
-            
+
             # Convert to legacy decision type for compatibility
             if smart_classification.complexity.value == "LOW":
                 decision_type = DecisionType.STRUCTURED
@@ -2037,7 +2438,7 @@ async def process_advanced_decision_step(
                 decision_type = DecisionType.INTUITIVE
             else:
                 decision_type = DecisionType.MIXED
-            
+
             # Create new advanced session with smart classification data
             session = {
                 "id": decision_id,
@@ -2048,7 +2449,7 @@ async def process_advanced_decision_step(
                     "complexity": smart_classification.complexity.value,
                     "intent": smart_classification.intent.value,
                     "routed_models": smart_classification.routed_models,
-                    "cost_estimate": smart_classification.cost_estimate
+                    "cost_estimate": smart_classification.cost_estimate,
                 },
                 "current_step": "initial",
                 "step_number": 1,
@@ -2057,33 +2458,37 @@ async def process_advanced_decision_step(
                 "versions": [],
                 "created_at": datetime.utcnow(),
                 "last_active": datetime.utcnow(),
-                "enable_personalization": request.enable_personalization
+                "enable_personalization": request.enable_personalization,
             }
-            
+
             await db.decision_sessions_advanced.insert_one(session)
-            
+
             # 🧠 HYBRID AI-LED: Generate ALL 3 questions upfront using decision coach approach
-            followup_questions = await ai_orchestrator.generate_smart_followup_questions(
-                request.message,
-                smart_classification,
-                session_id=decision_id,
-                max_questions=3
+            followup_questions = (
+                await ai_orchestrator.generate_smart_followup_questions(
+                    request.message,
+                    smart_classification,
+                    session_id=decision_id,
+                    max_questions=3,
+                )
             )
-            
+
             # Convert to response format with step numbers
             enhanced_questions = []
             for i, q in enumerate(followup_questions):
-                enhanced_questions.append(EnhancedFollowUpQuestion(
-                    question=q.question,
-                    nudge=q.nudge,
-                    category=q.category,
-                    step_number=i + 1,
-                    persona=q.persona
-                ))
-            
+                enhanced_questions.append(
+                    EnhancedFollowUpQuestion(
+                        question=q.question,
+                        nudge=q.nudge,
+                        category=q.category,
+                        step_number=i + 1,
+                        persona=q.persona,
+                    )
+                )
+
             # Store questions as dictionaries for consistent access
             question_dicts = [q.dict() for q in enhanced_questions]
-            
+
             # Store ALL questions in session upfront (Hybrid AI-Led approach)
             await db.decision_sessions_advanced.update_one(
                 {"id": decision_id},
@@ -2093,61 +2498,66 @@ async def process_advanced_decision_step(
                         "current_step": "followup",
                         "step_number": 1,  # Start with question 1
                         "total_questions": len(enhanced_questions),
-                        "last_active": datetime.utcnow()
+                        "last_active": datetime.utcnow(),
                     }
-                }
+                },
             )
-            
+
             response_text = f"I've analyzed your {decision_type.value} decision. Let me ask you some targeted questions to give you the best recommendation."
-            
+
             # Return ONLY the first question to match frontend step-by-step flow
             return AdvancedDecisionStepResponse(
                 decision_id=decision_id,
                 step="initial",
                 step_number=1,
                 response=response_text,
-                followup_questions=[enhanced_questions[0]] if enhanced_questions else [],  # Only first question
+                followup_questions=[enhanced_questions[0]]
+                if enhanced_questions
+                else [],  # Only first question
                 decision_type=decision_type.value,
-                session_version=1
+                session_version=1,
             )
-            
+
         elif request.step == "followup" and session:
             # 🧠 HYBRID AI-LED: Serve pre-generated questions one at a time
             stored_questions = session.get("followup_questions", [])
             current_step_number = session.get("step_number", 1)
             total_questions = session.get("total_questions", 3)
-            
+
             # Store the follow-up answer
             await db.decision_sessions_advanced.update_one(
                 {"id": decision_id},
                 {
                     "$push": {"followup_answers": request.message},
-                    "$set": {"last_active": datetime.utcnow()}
-                }
+                    "$set": {"last_active": datetime.utcnow()},
+                },
             )
-            
+
             current_answers = session.get("followup_answers", []) + [request.message]
             next_step_number = current_step_number + 1
-            
+
             # Check if we have more pre-generated questions to serve
-            if next_step_number <= total_questions and next_step_number <= len(stored_questions):
+            if next_step_number <= total_questions and next_step_number <= len(
+                stored_questions
+            ):
                 # Serve the next pre-generated question
-                next_question_data = stored_questions[next_step_number - 1]  # Array is 0-indexed
-                
+                next_question_data = stored_questions[
+                    next_step_number - 1
+                ]  # Array is 0-indexed
+
                 next_question = EnhancedFollowUpQuestion(
                     question=next_question_data.get("question", ""),
                     nudge=next_question_data.get("nudge", ""),
                     category=next_question_data.get("category", "general"),
                     step_number=next_step_number,
-                    persona=next_question_data.get("persona", "realist")
+                    persona=next_question_data.get("persona", "realist"),
                 )
-                
+
                 # Update step number
                 await db.decision_sessions_advanced.update_one(
-                    {"id": decision_id},
-                    {"$set": {"step_number": next_step_number}}
+                    {"id": decision_id}, {"$set": {"step_number": next_step_number}}
                 )
-                
+
                 return AdvancedDecisionStepResponse(
                     decision_id=decision_id,
                     step="followup",
@@ -2156,33 +2566,33 @@ async def process_advanced_decision_step(
                     followup_questions=[next_question],
                     is_complete=False,
                     decision_type=session.get("decision_type"),
-                    session_version=1
+                    session_version=1,
                 )
             else:
                 # All questions answered - ready for recommendation
                 await db.decision_sessions_advanced.update_one(
                     {"id": decision_id},
-                    {"$set": {"current_step": "ready_for_recommendation"}}
+                    {"$set": {"current_step": "ready_for_recommendation"}},
                 )
-                
+
                 # Generate the final recommendation using AI
                 return await _generate_advanced_recommendation(
                     decision_id, session, current_answers
                 )
-                
+
         elif request.step == "recommendation" and session:
             # Direct recommendation request
             current_answers = session.get("followup_answers", [])
             return await _generate_advanced_recommendation(
                 decision_id, session, current_answers
             )
-            
+
         elif request.step == "go_deeper" and session:
             # 🚀 OPTIONAL DEPTH ENHANCEMENT: Generate deeper questions based on all answers
             current_answers = session.get("followup_answers", [])
             initial_question = session.get("initial_question", "")
             smart_classification = session.get("smart_classification", {})
-            
+
             # Create context for deeper questions
             deeper_context = f"""Initial Question: {initial_question}
 
@@ -2190,19 +2600,21 @@ User's Answers to Previous Questions:
 {chr(10).join([f"Answer {i+1}: {answer}" for i, answer in enumerate(current_answers)])}
 
 Based on their answers, generate 1-2 deeper clarifying or exploratory questions that would help improve the final recommendation. Look for vagueness, conflicts, or areas that need more detail."""
-            
+
             try:
                 # Use enhanced model for deeper questions
-                deeper_questions = await ai_orchestrator.followup_engine.generate_smart_followups(
-                    deeper_context,
-                    {
-                        "complexity": "HIGH",  # Force deeper reasoning
-                        "intent": smart_classification.get("intent", "CLARITY")
-                    },
-                    ["claude-sonnet"],  # Use best model for depth
-                    f"{decision_id}_deeper"
+                deeper_questions = (
+                    await ai_orchestrator.followup_engine.generate_smart_followups(
+                        deeper_context,
+                        {
+                            "complexity": "HIGH",  # Force deeper reasoning
+                            "intent": smart_classification.get("intent", "CLARITY"),
+                        },
+                        ["claude-sonnet"],  # Use best model for depth
+                        f"{decision_id}_deeper",
+                    )
                 )
-                
+
                 if deeper_questions and len(deeper_questions) > 0:
                     # Take only 1-2 questions for depth
                     enhanced_deeper_questions = [
@@ -2211,22 +2623,25 @@ Based on their answers, generate 1-2 deeper clarifying or exploratory questions 
                             nudge=q["nudge"],
                             category=q["category"],
                             step_number=len(current_answers) + i + 1,
-                            persona=q["persona"]
-                        ) for i, q in enumerate(deeper_questions[:2])
+                            persona=q["persona"],
+                        )
+                        for i, q in enumerate(deeper_questions[:2])
                     ]
-                    
+
                     # Update session to track deeper questions
                     await db.decision_sessions_advanced.update_one(
                         {"id": decision_id},
                         {
                             "$set": {
                                 "current_step": "going_deeper",
-                                "deeper_questions": [q.dict() for q in enhanced_deeper_questions],
-                                "last_active": datetime.utcnow()
+                                "deeper_questions": [
+                                    q.dict() for q in enhanced_deeper_questions
+                                ],
+                                "last_active": datetime.utcnow(),
                             }
-                        }
+                        },
                     )
-                    
+
                     return AdvancedDecisionStepResponse(
                         decision_id=decision_id,
                         step="deeper",
@@ -2234,22 +2649,22 @@ Based on their answers, generate 1-2 deeper clarifying or exploratory questions 
                         response="Let me ask a couple more specific questions to give you an even better recommendation.",
                         followup_questions=enhanced_deeper_questions,
                         decision_type=session.get("decision_type"),
-                        session_version=1
+                        session_version=1,
                     )
-                    
+
             except Exception as e:
                 logging.warning(f"Deeper question generation failed: {e}")
-                
+
             # Fallback to direct recommendation
             return await _generate_advanced_recommendation(
                 decision_id, session, current_answers
             )
-            
+
         elif request.step == "adjust" and session:
             # Adjustment request - create new version
             current_version = session.get("version", 1)
             new_version = current_version + 1
-            
+
             # Store current version in history
             await db.decision_sessions_advanced.update_one(
                 {"id": decision_id},
@@ -2259,43 +2674,44 @@ Based on their answers, generate 1-2 deeper clarifying or exploratory questions 
                             "version": current_version,
                             "answers": session.get("followup_answers", []),
                             "recommendation": session.get("recommendation"),
-                            "created_at": datetime.utcnow()
+                            "created_at": datetime.utcnow(),
                         }
                     },
                     "$set": {
                         "version": new_version,
                         "adjustment_context": request.adjustment_context,
-                        "last_active": datetime.utcnow()
-                    }
-                }
+                        "last_active": datetime.utcnow(),
+                    },
+                },
             )
-            
+
             # Regenerate with adjustment context
             return await _generate_advanced_recommendation(
-                decision_id, session, session.get("followup_answers", []),
-                adjustment_context=request.adjustment_context
+                decision_id,
+                session,
+                session.get("followup_answers", []),
+                adjustment_context=request.adjustment_context,
             )
-            
+
         else:
             raise HTTPException(
-                status_code=404, 
-                detail="Decision session not found or invalid step"
+                status_code=404, detail="Decision session not found or invalid step"
             )
-            
+
     except HTTPException:
         raise
     except Exception as e:
         logger.error(f"Advanced decision processing error: {str(e)}")
         raise HTTPException(
-            status_code=500, 
-            detail="Error processing advanced decision"
+            status_code=500, detail="Error processing advanced decision"
         )
+
 
 async def _generate_advanced_recommendation(
     decision_id: str,
     session: dict,
     followup_answers: List[str],
-    adjustment_context: str = None
+    adjustment_context: str = None,
 ) -> AdvancedDecisionStepResponse:
     """
     Generate advanced recommendation using AI orchestrator
@@ -2304,7 +2720,7 @@ async def _generate_advanced_recommendation(
         decision_type = DecisionType(session.get("decision_type", "mixed"))
         initial_question = session.get("initial_question", "")
         enable_personalization = session.get("enable_personalization", False)
-        
+
         # Get user profile if personalization enabled
         user_profile = None
         if enable_personalization and session.get("user_id"):
@@ -2312,18 +2728,18 @@ async def _generate_advanced_recommendation(
             if user:
                 user_profile = {
                     "preferences": user.get("preferences", {}),
-                    "past_decisions": user.get("decision_history", [])
+                    "past_decisions": user.get("decision_history", []),
                 }
-        
+
         # Generate recommendation using AI orchestrator
         recommendation = await ai_orchestrator.synthesize_decision(
             initial_question=initial_question,
             followup_answers=followup_answers,
             decision_type=decision_type,
             user_profile=user_profile,
-            enable_personalization=enable_personalization
+            enable_personalization=enable_personalization,
         )
-        
+
         # Convert to response format
         enhanced_trace = EnhancedDecisionTrace(
             models_used=recommendation.trace.models_used,
@@ -2332,9 +2748,9 @@ async def _generate_advanced_recommendation(
             confidence_factors=recommendation.trace.confidence_factors,
             used_web_search=recommendation.trace.used_web_search,
             personas_consulted=recommendation.trace.personas_consulted,
-            processing_time_ms=recommendation.trace.processing_time_ms
+            processing_time_ms=recommendation.trace.processing_time_ms,
         )
-        
+
         enhanced_recommendation = EnhancedDecisionRecommendation(
             final_recommendation=recommendation.final_recommendation,
             summary=recommendation.summary,
@@ -2343,9 +2759,9 @@ async def _generate_advanced_recommendation(
             confidence_score=recommendation.confidence_score,
             confidence_tooltip=recommendation.confidence_tooltip,
             reasoning=recommendation.reasoning,
-            trace=enhanced_trace
+            trace=enhanced_trace,
         )
-        
+
         # Store recommendation in session
         await db.decision_sessions_advanced.update_one(
             {"id": decision_id},
@@ -2354,11 +2770,11 @@ async def _generate_advanced_recommendation(
                     "recommendation": enhanced_recommendation.dict(),
                     "current_step": "complete",
                     "completed_at": datetime.utcnow(),
-                    "last_active": datetime.utcnow()
+                    "last_active": datetime.utcnow(),
                 }
-            }
+            },
         )
-        
+
         return AdvancedDecisionStepResponse(
             decision_id=decision_id,
             step="complete",
@@ -2367,21 +2783,20 @@ async def _generate_advanced_recommendation(
             is_complete=True,
             recommendation=enhanced_recommendation,
             decision_type=session.get("decision_type"),
-            session_version=session.get("version", 1)
+            session_version=session.get("version", 1),
         )
-        
+
     except Exception as e:
         logger.error(f"Advanced recommendation generation error: {str(e)}")
         raise HTTPException(
-            status_code=500,
-            detail="Error generating advanced recommendation"
+            status_code=500, detail="Error generating advanced recommendation"
         )
+
 
 # Decision Version Management
 @api_router.get("/decision/{decision_id}/versions")
 async def get_decision_versions(
-    decision_id: str,
-    current_user: dict = Depends(get_current_user_optional)
+    decision_id: str, current_user: dict = Depends(get_current_user_optional)
 ):
     """
     Get all versions of a decision for comparison
@@ -2390,41 +2805,44 @@ async def get_decision_versions(
         session = await db.decision_sessions_advanced.find_one({"id": decision_id})
         if not session:
             raise HTTPException(status_code=404, detail="Decision session not found")
-        
+
         # Check permission
         user_id = current_user.get("id") if current_user else None
         if session.get("user_id") and session.get("user_id") != user_id:
             raise HTTPException(status_code=403, detail="Access denied")
-        
+
         versions = session.get("versions", [])
         current_version = {
             "version": session.get("version", 1),
             "answers": session.get("followup_answers", []),
             "recommendation": session.get("recommendation"),
-            "created_at": session.get("last_active", session.get("created_at"))
+            "created_at": session.get("last_active", session.get("created_at")),
         }
-        
+
         all_versions = versions + [current_version]
-        
+
         return {
             "decision_id": decision_id,
             "initial_question": session.get("initial_question"),
             "decision_type": session.get("decision_type"),
             "versions": all_versions,
-            "total_versions": len(all_versions)
+            "total_versions": len(all_versions),
         }
-        
+
     except HTTPException:
         raise
     except Exception as e:
         logger.error(f"Version retrieval error: {str(e)}")
-        raise HTTPException(status_code=500, detail="Error retrieving decision versions")
+        raise HTTPException(
+            status_code=500, detail="Error retrieving decision versions"
+        )
+
 
 @api_router.post("/decision/{decision_id}/compare")
 async def compare_decision_versions(
     decision_id: str,
     request: dict,
-    current_user: dict = Depends(get_current_user_optional)
+    current_user: dict = Depends(get_current_user_optional),
 ):
     """
     Compare two versions of a decision
@@ -2432,66 +2850,82 @@ async def compare_decision_versions(
     try:
         version1 = request.get("version1")
         version2 = request.get("version2")
-        
+
         if not version1 or not version2:
             raise HTTPException(status_code=400, detail="Both version numbers required")
-        
+
         session = await db.decision_sessions_advanced.find_one({"id": decision_id})
         if not session:
             raise HTTPException(status_code=404, detail="Decision session not found")
-        
+
         # Check permission
         user_id = current_user.get("id") if current_user else None
         if session.get("user_id") and session.get("user_id") != user_id:
             raise HTTPException(status_code=403, detail="Access denied")
-        
+
         versions = session.get("versions", [])
         current_version = {
             "version": session.get("version", 1),
             "answers": session.get("followup_answers", []),
             "recommendation": session.get("recommendation"),
-            "created_at": session.get("last_active")
+            "created_at": session.get("last_active"),
         }
-        
+
         all_versions = {v["version"]: v for v in versions + [current_version]}
-        
+
         if version1 not in all_versions or version2 not in all_versions:
             raise HTTPException(status_code=404, detail="Version not found")
-        
+
         v1_data = all_versions[version1]
         v2_data = all_versions[version2]
-        
+
         # Generate comparison analysis
         comparison = {
             "decision_id": decision_id,
             "version1": {
                 "version": version1,
-                "recommendation": v1_data.get("recommendation", {}).get("final_recommendation", ""),
-                "confidence": v1_data.get("recommendation", {}).get("confidence_score", 0),
+                "recommendation": v1_data.get("recommendation", {}).get(
+                    "final_recommendation", ""
+                ),
+                "confidence": v1_data.get("recommendation", {}).get(
+                    "confidence_score", 0
+                ),
                 "next_steps": v1_data.get("recommendation", {}).get("next_steps", []),
-                "created_at": v1_data.get("created_at")
+                "created_at": v1_data.get("created_at"),
             },
             "version2": {
                 "version": version2,
-                "recommendation": v2_data.get("recommendation", {}).get("final_recommendation", ""),
-                "confidence": v2_data.get("recommendation", {}).get("confidence_score", 0),
+                "recommendation": v2_data.get("recommendation", {}).get(
+                    "final_recommendation", ""
+                ),
+                "confidence": v2_data.get("recommendation", {}).get(
+                    "confidence_score", 0
+                ),
                 "next_steps": v2_data.get("recommendation", {}).get("next_steps", []),
-                "created_at": v2_data.get("created_at")
+                "created_at": v2_data.get("created_at"),
             },
             "differences": {
-                "confidence_change": v2_data.get("recommendation", {}).get("confidence_score", 0) - v1_data.get("recommendation", {}).get("confidence_score", 0),
-                "recommendation_changed": v1_data.get("recommendation", {}).get("final_recommendation", "") != v2_data.get("recommendation", {}).get("final_recommendation", ""),
-                "steps_changed": v1_data.get("recommendation", {}).get("next_steps", []) != v2_data.get("recommendation", {}).get("next_steps", [])
-            }
+                "confidence_change": v2_data.get("recommendation", {}).get(
+                    "confidence_score", 0
+                )
+                - v1_data.get("recommendation", {}).get("confidence_score", 0),
+                "recommendation_changed": v1_data.get("recommendation", {}).get(
+                    "final_recommendation", ""
+                )
+                != v2_data.get("recommendation", {}).get("final_recommendation", ""),
+                "steps_changed": v1_data.get("recommendation", {}).get("next_steps", [])
+                != v2_data.get("recommendation", {}).get("next_steps", []),
+            },
         }
-        
+
         return comparison
-        
+
     except HTTPException:
         raise
     except Exception as e:
         logger.error(f"Version comparison error: {str(e)}")
         raise HTTPException(status_code=500, detail="Error comparing decision versions")
+
 
 # Export Decision Endpoint
 @api_router.get("/decision/{decision_id}/export")
@@ -2499,7 +2933,7 @@ async def export_decision(
     decision_id: str,
     format: str = "json",
     include_trace: bool = False,
-    current_user: dict = Depends(get_current_user_optional)
+    current_user: dict = Depends(get_current_user_optional),
 ):
     """
     Export decision in various formats (JSON, PDF)
@@ -2508,14 +2942,14 @@ async def export_decision(
         session = await db.decision_sessions_advanced.find_one({"id": decision_id})
         if not session:
             raise HTTPException(status_code=404, detail="Decision session not found")
-        
+
         # Check permission
         user_id = current_user.get("id") if current_user else None
         if session.get("user_id") and session.get("user_id") != user_id:
             raise HTTPException(status_code=403, detail="Access denied")
-        
+
         recommendation = session.get("recommendation", {})
-        
+
         export_data = {
             "decision_id": decision_id,
             "question": session.get("initial_question"),
@@ -2525,25 +2959,28 @@ async def export_decision(
             "confidence_score": recommendation.get("confidence_score", 0),
             "reasoning": recommendation.get("reasoning", ""),
             "created_at": session.get("created_at"),
-            "completed_at": session.get("completed_at")
+            "completed_at": session.get("completed_at"),
         }
-        
+
         if include_trace:
             export_data["trace"] = recommendation.get("trace", {})
-        
+
         if format.lower() == "json":
             return export_data
         elif format.lower() == "pdf":
             # TODO: Implement PDF generation using reportlab/weasyprint
-            raise HTTPException(status_code=501, detail="PDF export not yet implemented")
+            raise HTTPException(
+                status_code=501, detail="PDF export not yet implemented"
+            )
         else:
             raise HTTPException(status_code=400, detail="Unsupported export format")
-            
+
     except HTTPException:
         raise
     except Exception as e:
         logger.error(f"Export error: {str(e)}")
         raise HTTPException(status_code=500, detail="Error exporting decision")
+
 
 # Decision Feedback Endpoint
 @api_router.post("/decision/feedback/{decision_id}")
@@ -2552,102 +2989,136 @@ async def submit_decision_feedback(decision_id: str, request: dict):
     try:
         helpful = request.get("helpful")
         feedback_text = request.get("feedback_text", "")
-        
+
         if helpful is None:
-            raise HTTPException(status.HTTP_400_BAD_REQUEST, "helpful field is required")
-        
+            raise HTTPException(
+                status.HTTP_400_BAD_REQUEST, "helpful field is required"
+            )
+
         # Store feedback in database
         feedback_doc = {
             "decision_id": decision_id,
             "helpful": helpful,
             "feedback_text": feedback_text,
-            "timestamp": datetime.utcnow()
+            "timestamp": datetime.utcnow(),
         }
-        
+
         await db.decision_feedback.insert_one(feedback_doc)
-        
-        return {"message": "Feedback submitted successfully", "decision_id": decision_id}
-        
+
+        return {
+            "message": "Feedback submitted successfully",
+            "decision_id": decision_id,
+        }
+
     except HTTPException:
         raise
     except Exception as e:
         logging.error(f"Error submitting feedback: {str(e)}")
-        raise HTTPException(status.HTTP_500_INTERNAL_SERVER_ERROR, "Error submitting feedback")
+        raise HTTPException(
+            status.HTTP_500_INTERNAL_SERVER_ERROR, "Error submitting feedback"
+        )
+
 
 @api_router.get("/decisions")
-async def get_user_decisions(current_user: dict = Depends(get_current_user), limit: int = 20):
+async def get_user_decisions(
+    current_user: dict = Depends(get_current_user), limit: int = 20
+):
     """Get list of user's decision sessions"""
     try:
-        decisions = await db.decision_sessions.find(
-            {"user_id": current_user["id"], "is_active": True}
-        ).sort("last_active", -1).limit(limit).to_list(limit)
-        
+        decisions = (
+            await db.decision_sessions.find(
+                {"user_id": current_user["id"], "is_active": True}
+            )
+            .sort("last_active", -1)
+            .limit(limit)
+            .to_list(limit)
+        )
+
         for decision in decisions:
             if "_id" in decision:
                 decision["_id"] = str(decision["_id"])
-        
+
         return {"decisions": decisions}
     except Exception as e:
         logging.error(f"Error getting decisions: {str(e)}")
-        raise HTTPException(status.HTTP_500_INTERNAL_SERVER_ERROR, "Error retrieving decisions")
+        raise HTTPException(
+            status.HTTP_500_INTERNAL_SERVER_ERROR, "Error retrieving decisions"
+        )
+
 
 @api_router.get("/decisions/{decision_id}/history")
-async def get_decision_history(decision_id: str, current_user: dict = Depends(get_current_user), limit: int = 20):
+async def get_decision_history(
+    decision_id: str, current_user: dict = Depends(get_current_user), limit: int = 20
+):
     """Get conversation history for a specific decision"""
     try:
-        conversations = await db.conversations.find(
-            {"decision_id": decision_id, "user_id": current_user["id"]}
-        ).sort("timestamp", 1).limit(limit).to_list(limit)
-        
+        conversations = (
+            await db.conversations.find(
+                {"decision_id": decision_id, "user_id": current_user["id"]}
+            )
+            .sort("timestamp", 1)
+            .limit(limit)
+            .to_list(limit)
+        )
+
         for conv in conversations:
             if "_id" in conv:
                 conv["_id"] = str(conv["_id"])
-        
+
         return {"conversations": conversations}
     except Exception as e:
         logging.error(f"Error getting conversation history: {str(e)}")
-        raise HTTPException(status.HTTP_500_INTERNAL_SERVER_ERROR, "Error retrieving conversation history")
+        raise HTTPException(
+            status.HTTP_500_INTERNAL_SERVER_ERROR,
+            "Error retrieving conversation history",
+        )
+
 
 @api_router.get("/decisions/{decision_id}")
-async def get_decision_info(decision_id: str, current_user: dict = Depends(get_current_user)):
+async def get_decision_info(
+    decision_id: str, current_user: dict = Depends(get_current_user)
+):
     """Get decision session information"""
     try:
-        decision = await db.decision_sessions.find_one({"decision_id": decision_id, "user_id": current_user["id"]})
+        decision = await db.decision_sessions.find_one(
+            {"decision_id": decision_id, "user_id": current_user["id"]}
+        )
         if not decision:
             return {
-                "decision_id": decision_id, 
-                "title": "New Decision", 
-                "category": "general", 
-                "user_preferences": {}, 
+                "decision_id": decision_id,
+                "title": "New Decision",
+                "category": "general",
+                "user_preferences": {},
                 "message_count": 0,
                 "llm_preference": "auto",
-                "advisor_style": "realist"
+                "advisor_style": "realist",
             }
-        
+
         if "_id" in decision:
             decision["_id"] = str(decision["_id"])
-        
+
         return decision
     except Exception as e:
         logging.error(f"Error getting decision info: {str(e)}")
-        raise HTTPException(status.HTTP_500_INTERNAL_SERVER_ERROR, "Error retrieving decision information")
+        raise HTTPException(
+            status.HTTP_500_INTERNAL_SERVER_ERROR,
+            "Error retrieving decision information",
+        )
+
 
 class SmartFollowupEngine:
     """Hybrid AI-Led Follow-Up Engine - Generates 3 intelligent questions upfront"""
-    
+
     @staticmethod
     async def generate_smart_followups(
-        user_message: str, 
-        classification: dict, 
-        models: list,
-        session_id: str
+        user_message: str, classification: dict, models: list, session_id: str
     ) -> list:
         """Generate 3 smart follow-up questions using AI reasoning in one shot"""
-        
+
         # 🧠 HYBRID AI-LED APPROACH: Generate all 3 questions upfront with intelligent planning
-        complexity = classification.get('complexity', 'MEDIUM')
-        intent = classification.get('intent', 'CLARITY')
-        
+        complexity = classification.get("complexity", "MEDIUM")
+        intent = classification.get("intent", "CLARITY")
+
         # 🎯 SMART MODEL ROUTING based on complexity
         if complexity == "LOW":
             primary_model = "claude-haiku"  # Cheapest, sufficient
@@ -2655,11 +3126,11 @@ class SmartFollowupEngine:
             primary_model = "claude-sonnet"  # Deepest reasoning
         else:
             primary_model = "gpt4o-mini"  # Good balance for medium complexity
-        
+
         # Use first available model from routing if specified
         if models and len(models) > 0:
             primary_model = models[0]
-        
+
         # 🧩 DECISION COACH PROMPT: Think like a human coach who plans ahead
         followup_prompt = f"""You are a decision coach AI helping a user gain clarity on their decision.
 
@@ -2712,100 +3183,119 @@ Generate exactly 3 questions that will give you the best foundation for an excel
             if primary_model.startswith("claude"):
                 api_key = ANTHROPIC_API_KEY
                 provider = "anthropic"
-                model_name = LLM_MODELS.get(primary_model, {}).get("model", "claude-haiku-3-20240307")
+                model_name = LLM_MODELS.get(primary_model, {}).get(
+                    "model", "claude-haiku-3-20240307"
+                )
             else:
                 api_key = OPENAI_API_KEY
                 provider = "openai"
-                model_name = LLM_MODELS.get(primary_model, {}).get("model", "gpt-4o-mini")
-            
-            chat = LlmChat(
-                api_key=api_key,
-                session_id=session_id,
-                system_message=followup_prompt
-            ).with_model(provider, model_name).with_max_tokens(1500)
-            
-            user_msg = UserMessage(text=f"Generate 3 thoughtful follow-up questions for: {user_message}")
+                model_name = LLM_MODELS.get(primary_model, {}).get(
+                    "model", "gpt-4o-mini"
+                )
+
+            chat = (
+                LlmChat(
+                    api_key=api_key,
+                    session_id=session_id,
+                    system_message=followup_prompt,
+                )
+                .with_model(provider, model_name)
+                .with_max_tokens(1500)
+            )
+
+            user_msg = UserMessage(
+                text=f"Generate 3 thoughtful follow-up questions for: {user_message}"
+            )
             response = await chat.send_message(user_msg)
-            
+
             # Parse JSON response
             import json
+
             response_clean = response.strip()
-            if response_clean.startswith('```json'):
+            if response_clean.startswith("```json"):
                 response_clean = response_clean[7:-3]
-            elif response_clean.startswith('```'):
+            elif response_clean.startswith("```"):
                 response_clean = response_clean[3:-3]
-            
+
             followups_data = json.loads(response_clean)
-            
+
             # Validate and format questions
             questions = []
             for i, q_data in enumerate(followups_data.get("questions", [])):
                 if len(questions) >= 3:  # Exactly 3 questions
                     break
-                    
+
                 persona = q_data.get("persona", "realist").lower()
                 if persona not in FOLLOWUP_PERSONAS:
                     persona = "realist"
-                
+
                 # Store as dictionary for consistent access
-                questions.append({
-                    "question": q_data.get("q", ""),
-                    "nudge": q_data.get("nudge", ""),
-                    "persona": persona,
-                    "category": intent.lower(),
-                    "step_number": i + 1
-                })
-            
+                questions.append(
+                    {
+                        "question": q_data.get("q", ""),
+                        "nudge": q_data.get("nudge", ""),
+                        "persona": persona,
+                        "category": intent.lower(),
+                        "step_number": i + 1,
+                    }
+                )
+
             # Ensure we have exactly 3 questions
             while len(questions) < 3:
-                questions.append({
-                    "question": "What factors are most important to you in making this decision?",
-                    "nudge": "e.g., timing, cost, impact on others, personal values",
-                    "persona": "pragmatist",
-                    "category": intent.lower(),
-                    "step_number": len(questions) + 1
-                })
-            
+                questions.append(
+                    {
+                        "question": "What factors are most important to you in making this decision?",
+                        "nudge": "e.g., timing, cost, impact on others, personal values",
+                        "persona": "pragmatist",
+                        "category": intent.lower(),
+                        "step_number": len(questions) + 1,
+                    }
+                )
+
             # Convert to FollowUpQuestion objects for consistency
             followup_question_objects = []
             for i, q in enumerate(questions):
-                followup_question_objects.append(FollowUpQuestion(
-                    question=q.get("question", ""),
-                    nudge=q.get("nudge", ""),
-                    category=q.get("category", "general"),
-                    persona=q.get("persona", "realist")
-                ))
-            
-            return followup_question_objects[:3]  # Return exactly 3 FollowUpQuestion objects
-            
+                followup_question_objects.append(
+                    FollowUpQuestion(
+                        question=q.get("question", ""),
+                        nudge=q.get("nudge", ""),
+                        category=q.get("category", "general"),
+                        persona=q.get("persona", "realist"),
+                    )
+                )
+
+            return followup_question_objects[
+                :3
+            ]  # Return exactly 3 FollowUpQuestion objects
+
         except Exception as e:
             logging.warning(f"AI-led followup generation failed: {str(e)}")
             # Fallback to structured questions
             return SmartFollowupEngine._generate_fallback_questions(classification)
-    
+
     @staticmethod
     def _generate_fallback_questions(classification: dict) -> list:
         """Generate fallback questions if AI generation fails"""
-        
+
         complexity = classification.get("complexity", "MEDIUM")
         intent = classification.get("intent", "CLARITY")
-        
+
         base_questions = []
-        
+
         if complexity == "HIGH":
             base_questions = [
                 {
                     "question": "What emotions are driving this decision?",
                     "nudge": "e.g., fear, excitement, uncertainty, hope",
                     "persona": "supportive",
-                    "category": "emotions"
+                    "category": "emotions",
                 },
                 {
                     "question": "What would success look like to you?",
                     "nudge": "e.g., peace of mind, new opportunities, growth",
                     "persona": "visionary",
-                    "category": "outcomes"
-                }
+                    "category": "outcomes",
+                },
             ]
         elif complexity == "MEDIUM":
             base_questions = [
@@ -2813,14 +3303,14 @@ Generate exactly 3 questions that will give you the best foundation for an excel
                     "question": "What factors matter most to you?",
                     "nudge": "e.g., time, money, relationships, career growth",
                     "persona": "pragmatist",
-                    "category": "priorities"
+                    "category": "priorities",
                 },
                 {
                     "question": "What constraints are you working with?",
                     "nudge": "e.g., budget limits, deadlines, location",
                     "persona": "realist",
-                    "category": "constraints"
-                }
+                    "category": "constraints",
+                },
             ]
         else:  # LOW
             base_questions = [
@@ -2828,19 +3318,26 @@ Generate exactly 3 questions that will give you the best foundation for an excel
                     "question": "When do you need to decide?",
                     "nudge": "e.g., this week, next month, just exploring",
                     "persona": "realist",
-                    "category": "timing"
+                    "category": "timing",
                 }
             ]
-        
+
         return base_questions[:2]  # Return max 2 fallback questions
 
-def generate_demo_response(message: str, category: str = "general", user_preferences: dict = None, conversation_history: List[dict] = None, advisor_style: str = "realist") -> str:
+
+def generate_demo_response(
+    message: str,
+    category: str = "general",
+    user_preferences: dict = None,
+    conversation_history: List[dict] = None,
+    advisor_style: str = "realist",
+) -> str:
     """Generate demo responses when both LLMs fail"""
-    
+
     advisor_config = ADVISOR_STYLES.get(advisor_style, ADVISOR_STYLES["realist"])
-    
+
     response = f"As your getgingee {advisor_config['name']} Advisor, I'm here to help! {advisor_config['motto']}\n\n"
-    
+
     if advisor_style == "optimistic":
         response += "This is a wonderful opportunity to make a positive change! Here's how I see your options with excitement:\n\n"
     elif advisor_style == "skeptical":
@@ -2848,16 +3345,20 @@ def generate_demo_response(message: str, category: str = "general", user_prefere
     elif advisor_style == "creative":
         response += "What an interesting challenge! Let me help you explore this from some creative angles:\n\n"
     elif advisor_style == "analytical":
-        response += "Let's break this down systematically with data and logical frameworks:\n\n"
+        response += (
+            "Let's break this down systematically with data and logical frameworks:\n\n"
+        )
     elif advisor_style == "intuitive":
-        response += "Let's tune into your inner wisdom and see what feels right for you:\n\n"
+        response += (
+            "Let's tune into your inner wisdom and see what feels right for you:\n\n"
+        )
     elif advisor_style == "visionary":
         response += "Let's think big picture and consider how this decision shapes your future:\n\n"
     elif advisor_style == "supportive":
         response += "I understand this decision feels important to you. Let's work through this together:\n\n"
     else:  # realist
         response += "Let's approach this systematically and consider all the practical factors:\n\n"
-    
+
     response += f"""**Using My {advisor_config['framework']}:**
 1. **Your values and priorities** - What matters most to you in this situation?
 2. **Key considerations** - {advisor_config['decision_weight']} factors
@@ -2867,28 +3368,33 @@ def generate_demo_response(message: str, category: str = "general", user_prefere
 I suggest taking a structured approach that aligns with your {advisor_style} needs and my expertise in {advisor_config['framework'].lower()}.
 
 *Note: This is a demo response. Both Claude and GPT-4o are temporarily unavailable.*"""
-    
+
     return response
+
 
 # Payment and Billing Endpoints
 @api_router.post("/payments/create-payment-link", response_model=PaymentResponse)
-async def create_payment_link(request: PaymentRequest, current_user: dict = Depends(get_current_user)):
+async def create_payment_link(
+    request: PaymentRequest, current_user: dict = Depends(get_current_user)
+):
     """Create a payment link for credit pack purchase"""
     try:
         if not dodo_payments:
-            raise HTTPException(status.HTTP_503_SERVICE_UNAVAILABLE, "Payment service not available")
-        
+            raise HTTPException(
+                status.HTTP_503_SERVICE_UNAVAILABLE, "Payment service not available"
+            )
+
         # Validate product
         if request.product_id not in CREDIT_PACKS:
-            raise HTTPException(status.HTTP_400_BAD_REQUEST, f"Invalid product ID: {request.product_id}")
-        
+            raise HTTPException(
+                status.HTTP_400_BAD_REQUEST, f"Invalid product ID: {request.product_id}"
+            )
+
         # Create payment link
         payment_response = await dodo_payments.create_payment_link(
-            request, 
-            current_user["id"],
-            f"{FRONTEND_URL}/billing/success"
+            request, current_user["id"], f"{FRONTEND_URL}/billing/success"
         )
-        
+
         # Store payment record
         product = CREDIT_PACKS[request.product_id]
         payment_doc = PaymentDocument(
@@ -2903,41 +3409,48 @@ async def create_payment_link(request: PaymentRequest, current_user: dict = Depe
             status="pending",
             metadata={
                 "payment_link": payment_response.payment_link,
-                "dodo_product_id": product["id"]
-            }
+                "dodo_product_id": product["id"],
+            },
         )
-        
+
         await db.payments.insert_one(payment_doc.dict())
-        
+
         return payment_response
-        
+
     except Exception as e:
         logging.error(f"Error creating payment link: {str(e)}")
-        raise HTTPException(status.HTTP_500_INTERNAL_SERVER_ERROR, f"Failed to create payment link: {str(e)}")
+        raise HTTPException(
+            status.HTTP_500_INTERNAL_SERVER_ERROR,
+            f"Failed to create payment link: {str(e)}",
+        )
+
 
 @api_router.post("/payments/create-subscription", response_model=SubscriptionResponse)
-async def create_subscription(request: SubscriptionRequest, current_user: dict = Depends(get_current_user)):
+async def create_subscription(
+    request: SubscriptionRequest, current_user: dict = Depends(get_current_user)
+):
     """Create a Pro plan subscription"""
     try:
         if not dodo_payments:
-            raise HTTPException(status.HTTP_503_SERVICE_UNAVAILABLE, "Payment service not available")
-        
+            raise HTTPException(
+                status.HTTP_503_SERVICE_UNAVAILABLE, "Payment service not available"
+            )
+
         # Check if user already has active subscription
-        existing_sub = await db.subscriptions.find_one({
-            "user_id": current_user["id"],
-            "status": {"$in": ["active", "trialing"]}
-        })
-        
+        existing_sub = await db.subscriptions.find_one(
+            {"user_id": current_user["id"], "status": {"$in": ["active", "trialing"]}}
+        )
+
         if existing_sub:
-            raise HTTPException(status.HTTP_400_BAD_REQUEST, "User already has an active subscription")
-        
+            raise HTTPException(
+                status.HTTP_400_BAD_REQUEST, "User already has an active subscription"
+            )
+
         # Create subscription
         subscription_response = await dodo_payments.create_subscription(
-            request,
-            current_user["id"],
-            f"{FRONTEND_URL}/billing/success"
+            request, current_user["id"], f"{FRONTEND_URL}/billing/success"
         )
-        
+
         # Store subscription record
         plan = SUBSCRIPTION_PRODUCTS[request.plan_id]
         subscription_doc = SubscriptionDocument(
@@ -2950,104 +3463,128 @@ async def create_subscription(request: SubscriptionRequest, current_user: dict =
             billing_cycle=request.billing_cycle,
             status="active",
             current_period_start=datetime.utcnow(),
-            current_period_end=subscription_response.current_period_end
+            current_period_end=subscription_response.current_period_end,
         )
-        
+
         await db.subscriptions.insert_one(subscription_doc.dict())
-        
+
         # Upgrade user to Pro plan
         await db.users.update_one(
             {"id": current_user["id"]},
-            {"$set": {"plan": "pro", "subscription_expires": subscription_response.current_period_end}}
+            {
+                "$set": {
+                    "plan": "pro",
+                    "subscription_expires": subscription_response.current_period_end,
+                }
+            },
         )
-        
+
         return subscription_response
-        
+
     except Exception as e:
         logging.error(f"Error creating subscription: {str(e)}")
-        raise HTTPException(status.HTTP_500_INTERNAL_SERVER_ERROR, f"Failed to create subscription: {str(e)}")
+        raise HTTPException(
+            status.HTTP_500_INTERNAL_SERVER_ERROR,
+            f"Failed to create subscription: {str(e)}",
+        )
+
 
 @api_router.get("/payments/billing-history")
 async def get_billing_history(current_user: dict = Depends(get_current_user)):
     """Get user's billing history including payments and subscriptions"""
     try:
         # Get payments
-        payments_cursor = db.payments.find({"user_id": current_user["id"]}).sort("created_at", -1)
+        payments_cursor = db.payments.find({"user_id": current_user["id"]}).sort(
+            "created_at", -1
+        )
         payments = await payments_cursor.to_list(50)
-        
+
         # Get subscriptions
-        subscriptions_cursor = db.subscriptions.find({"user_id": current_user["id"]}).sort("created_at", -1)
+        subscriptions_cursor = db.subscriptions.find(
+            {"user_id": current_user["id"]}
+        ).sort("created_at", -1)
         subscriptions = await subscriptions_cursor.to_list(10)
-        
+
         # Find active subscription
         active_subscription = None
         for sub in subscriptions:
             if sub.get("status") == "active":
                 active_subscription = sub
                 break
-        
+
         # Calculate total spent
         total_spent = 0
         for payment in payments:
             if payment.get("status") == "succeeded":
                 total_spent += float(payment.get("amount", 0))
-        
+
         for sub in subscriptions:
             if sub.get("status") in ["active", "cancelled"]:
                 total_spent += float(sub.get("amount", 0))
-        
+
         # Clean up ObjectIds
         for payment in payments:
             if "_id" in payment:
                 payment["_id"] = str(payment["_id"])
-        
+
         for sub in subscriptions:
             if "_id" in sub:
                 sub["_id"] = str(sub["_id"])
-        
+
         if active_subscription and "_id" in active_subscription:
             active_subscription["_id"] = str(active_subscription["_id"])
-        
+
         return {
             "payments": payments,
             "subscriptions": subscriptions,
             "active_subscription": active_subscription,
-            "total_spent": total_spent
+            "total_spent": total_spent,
         }
-        
+
     except Exception as e:
         logging.error(f"Error getting billing history: {str(e)}")
-        raise HTTPException(status.HTTP_500_INTERNAL_SERVER_ERROR, "Failed to retrieve billing history")
+        raise HTTPException(
+            status.HTTP_500_INTERNAL_SERVER_ERROR, "Failed to retrieve billing history"
+        )
+
 
 @api_router.get("/payments/credit-packs")
 async def get_credit_packs():
     """Get available credit packs"""
     return {"credit_packs": CREDIT_PACKS}
 
+
 @api_router.get("/payments/subscription-plans")
 async def get_subscription_plans():
     """Get available subscription plans"""
     return {"subscription_plans": SUBSCRIPTION_PRODUCTS}
+
 
 @api_router.post("/payments/cancel-subscription")
 async def cancel_subscription(current_user: dict = Depends(get_current_user)):
     """Cancel user's active subscription"""
     try:
         # Find active subscription
-        subscription = await db.subscriptions.find_one({
-            "user_id": current_user["id"],
-            "status": "active"
-        })
-        
+        subscription = await db.subscriptions.find_one(
+            {"user_id": current_user["id"], "status": "active"}
+        )
+
         if not subscription:
-            raise HTTPException(status.HTTP_404_NOT_FOUND, "No active subscription found")
-        
+            raise HTTPException(
+                status.HTTP_404_NOT_FOUND, "No active subscription found"
+            )
+
         # Cancel with Dodo Payments if we have the subscription ID
         if subscription.get("dodo_subscription_id") and dodo_payments:
-            success = await dodo_payments.cancel_subscription(subscription["dodo_subscription_id"])
+            success = await dodo_payments.cancel_subscription(
+                subscription["dodo_subscription_id"]
+            )
             if not success:
-                raise HTTPException(status.HTTP_500_INTERNAL_SERVER_ERROR, "Failed to cancel subscription with payment provider")
-        
+                raise HTTPException(
+                    status.HTTP_500_INTERNAL_SERVER_ERROR,
+                    "Failed to cancel subscription with payment provider",
+                )
+
         # Update subscription status
         await db.subscriptions.update_one(
             {"id": subscription["id"]},
@@ -3056,22 +3593,25 @@ async def cancel_subscription(current_user: dict = Depends(get_current_user)):
                     "status": "cancelled",
                     "cancel_at_period_end": True,
                     "cancelled_at": datetime.utcnow(),
-                    "updated_at": datetime.utcnow()
+                    "updated_at": datetime.utcnow(),
                 }
-            }
+            },
         )
-        
+
         # Downgrade user to free plan at period end
         await db.users.update_one(
-            {"id": current_user["id"]},
-            {"$set": {"plan": "free"}}
+            {"id": current_user["id"]}, {"$set": {"plan": "free"}}
         )
-        
+
         return {"message": "Subscription cancelled successfully"}
-        
+
     except Exception as e:
         logging.error(f"Error cancelling subscription: {str(e)}")
-        raise HTTPException(status.HTTP_500_INTERNAL_SERVER_ERROR, f"Failed to cancel subscription: {str(e)}")
+        raise HTTPException(
+            status.HTTP_500_INTERNAL_SERVER_ERROR,
+            f"Failed to cancel subscription: {str(e)}",
+        )
+
 
 @api_router.post("/webhooks/dodo", include_in_schema=False)
 async def handle_dodo_webhook(request: Request):
@@ -3080,39 +3620,49 @@ async def handle_dodo_webhook(request: Request):
         body = await request.body()
         signature = request.headers.get("webhook-signature", "")
         timestamp = request.headers.get("webhook-timestamp", "")
-        
+
         # Enhanced webhook verification
         if not signature or not timestamp:
             logger.warning("Webhook received without proper signature headers")
-            raise HTTPException(status.HTTP_401_UNAUTHORIZED, "Missing webhook signature")
-        
+            raise HTTPException(
+                status.HTTP_401_UNAUTHORIZED, "Missing webhook signature"
+            )
+
         # Check timestamp to prevent replay attacks
         try:
-            webhook_time = datetime.fromisoformat(timestamp.replace('Z', '+00:00'))
+            webhook_time = datetime.fromisoformat(timestamp.replace("Z", "+00:00"))
             time_diff = datetime.utcnow() - webhook_time
             if time_diff.total_seconds() > 300:  # 5 minutes tolerance
-                raise HTTPException(status.HTTP_401_UNAUTHORIZED, "Webhook timestamp too old")
+                raise HTTPException(
+                    status.HTTP_401_UNAUTHORIZED, "Webhook timestamp too old"
+                )
         except ValueError:
             logger.warning(f"Invalid webhook timestamp: {timestamp}")
-            raise HTTPException(status.HTTP_401_UNAUTHORIZED, "Invalid webhook timestamp")
-        
+            raise HTTPException(
+                status.HTTP_401_UNAUTHORIZED, "Invalid webhook timestamp"
+            )
+
         # Verify webhook signature
-        if dodo_payments and not await dodo_payments.verify_webhook_signature(body, signature, timestamp):
+        if dodo_payments and not await dodo_payments.verify_webhook_signature(
+            body, signature, timestamp
+        ):
             logger.warning("Webhook signature verification failed")
-            raise HTTPException(status.HTTP_401_UNAUTHORIZED, "Invalid webhook signature")
-        
+            raise HTTPException(
+                status.HTTP_401_UNAUTHORIZED, "Invalid webhook signature"
+            )
+
         try:
             payload = json.loads(body)
         except json.JSONDecodeError:
             logger.error("Invalid JSON in webhook payload")
             raise HTTPException(status.HTTP_400_BAD_REQUEST, "Invalid JSON payload")
-        
+
         event_type = payload.get("type")
         data = payload.get("data", {})
-        
+
         # Log webhook received
         logger.info(f"Verified Dodo webhook received: {event_type}")
-        
+
         # Process webhook events
         if event_type == "payment.succeeded":
             await process_successful_payment(data)
@@ -3126,26 +3676,29 @@ async def handle_dodo_webhook(request: Request):
             await process_subscription_updated(data)
         else:
             logger.warning(f"Unknown webhook event type: {event_type}")
-        
+
         return {"status": "received", "event_type": event_type}
-        
+
     except HTTPException:
         raise
     except Exception as e:
         logger.error(f"Error processing webhook: {str(e)}")
-        raise HTTPException(status.HTTP_500_INTERNAL_SERVER_ERROR, "Webhook processing failed")
+        raise HTTPException(
+            status.HTTP_500_INTERNAL_SERVER_ERROR, "Webhook processing failed"
+        )
+
 
 async def process_successful_payment(data: dict):
     """Process successful payment webhook"""
     try:
         payment_id = data.get("payment_id") or data.get("id")
-        
+
         # Find payment record
         payment = await db.payments.find_one({"dodo_payment_id": payment_id})
         if not payment:
             logging.warning(f"Payment not found for Dodo payment ID: {payment_id}")
             return
-        
+
         # Update payment status
         await db.payments.update_one(
             {"id": payment["id"]},
@@ -3153,80 +3706,76 @@ async def process_successful_payment(data: dict):
                 "$set": {
                     "status": "succeeded",
                     "updated_at": datetime.utcnow(),
-                    "payment_method": data.get("payment_method")
+                    "payment_method": data.get("payment_method"),
                 }
-            }
+            },
         )
-        
+
         # Add credits to user account
         if payment.get("credits_amount", 0) > 0:
             await db.users.update_one(
                 {"id": payment["user_id"]},
-                {"$inc": {"credits": payment["credits_amount"]}}
+                {"$inc": {"credits": payment["credits_amount"]}},
             )
-            
+
         logging.info(f"Payment processed successfully: {payment_id}")
-        
+
     except Exception as e:
         logging.error(f"Error processing successful payment: {str(e)}")
+
 
 async def process_failed_payment(data: dict):
     """Process failed payment webhook"""
     try:
         payment_id = data.get("payment_id") or data.get("id")
-        
+
         await db.payments.update_one(
             {"dodo_payment_id": payment_id},
-            {
-                "$set": {
-                    "status": "failed",
-                    "updated_at": datetime.utcnow()
-                }
-            }
+            {"$set": {"status": "failed", "updated_at": datetime.utcnow()}},
         )
-        
+
         logging.info(f"Payment marked as failed: {payment_id}")
-        
+
     except Exception as e:
         logging.error(f"Error processing failed payment: {str(e)}")
+
 
 async def process_subscription_created(data: dict):
     """Process subscription created webhook"""
     try:
         subscription_id = data.get("subscription_id") or data.get("id")
-        
+
         # Find subscription record
-        subscription = await db.subscriptions.find_one({"dodo_subscription_id": subscription_id})
+        subscription = await db.subscriptions.find_one(
+            {"dodo_subscription_id": subscription_id}
+        )
         if not subscription:
-            logging.warning(f"Subscription not found for Dodo subscription ID: {subscription_id}")
+            logging.warning(
+                f"Subscription not found for Dodo subscription ID: {subscription_id}"
+            )
             return
-        
+
         # Upgrade user to Pro plan
         await db.users.update_one(
-            {"id": subscription["user_id"]},
-            {"$set": {"plan": "pro"}}
+            {"id": subscription["user_id"]}, {"$set": {"plan": "pro"}}
         )
-        
+
         await db.subscriptions.update_one(
             {"id": subscription["id"]},
-            {
-                "$set": {
-                    "status": "active",
-                    "updated_at": datetime.utcnow()
-                }
-            }
+            {"$set": {"status": "active", "updated_at": datetime.utcnow()}},
         )
-        
+
         logging.info(f"Subscription activated: {subscription_id}")
-        
+
     except Exception as e:
         logging.error(f"Error processing subscription created: {str(e)}")
+
 
 async def process_subscription_cancelled(data: dict):
     """Process subscription cancelled webhook"""
     try:
         subscription_id = data.get("subscription_id") or data.get("id")
-        
+
         # Update subscription status
         await db.subscriptions.update_one(
             {"dodo_subscription_id": subscription_id},
@@ -3234,203 +3783,233 @@ async def process_subscription_cancelled(data: dict):
                 "$set": {
                     "status": "cancelled",
                     "cancelled_at": datetime.utcnow(),
-                    "updated_at": datetime.utcnow()
+                    "updated_at": datetime.utcnow(),
                 }
-            }
+            },
         )
-        
+
         # Find user and downgrade to free plan
-        subscription = await db.subscriptions.find_one({"dodo_subscription_id": subscription_id})
+        subscription = await db.subscriptions.find_one(
+            {"dodo_subscription_id": subscription_id}
+        )
         if subscription:
             await db.users.update_one(
-                {"id": subscription["user_id"]},
-                {"$set": {"plan": "free"}}
+                {"id": subscription["user_id"]}, {"$set": {"plan": "free"}}
             )
-        
+
         logging.info(f"Subscription cancelled: {subscription_id}")
-        
+
     except Exception as e:
         logging.error(f"Error processing subscription cancelled: {str(e)}")
+
 
 async def process_subscription_updated(data: dict):
     """Process subscription updated webhook"""
     try:
         subscription_id = data.get("subscription_id") or data.get("id")
-        
+
         await db.subscriptions.update_one(
             {"dodo_subscription_id": subscription_id},
-            {
-                "$set": {
-                    "updated_at": datetime.utcnow()
-                }
-            }
+            {"$set": {"updated_at": datetime.utcnow()}},
         )
-        
+
         logging.info(f"Subscription updated: {subscription_id}")
-        
+
     except Exception as e:
         logging.error(f"Error processing subscription updated: {str(e)}")
 
+
 # Decision Export & Sharing Endpoints
 @api_router.post("/decisions/{decision_id}/export-pdf")
-async def export_decision_pdf(decision_id: str, current_user: dict = Depends(get_current_user)):
+async def export_decision_pdf(
+    decision_id: str, current_user: dict = Depends(get_current_user)
+):
     """Export a decision session to PDF (Pro feature)"""
     try:
         # Check if user has Pro plan
         if current_user.get("plan") != "pro":
             raise HTTPException(
-                status.HTTP_403_FORBIDDEN, 
-                "PDF export requires Pro subscription"
+                status.HTTP_403_FORBIDDEN, "PDF export requires Pro subscription"
             )
-        
+
         # Get decision data
-        decision = await db.decision_sessions.find_one({
-            "decision_id": decision_id,
-            "user_id": current_user["id"]
-        })
-        
+        decision = await db.decision_sessions.find_one(
+            {"decision_id": decision_id, "user_id": current_user["id"]}
+        )
+
         if not decision:
             raise HTTPException(status.HTTP_404_NOT_FOUND, "Decision not found")
-        
+
         # Get conversation history
-        conversations = await db.conversations.find({
-            "decision_id": decision_id,
-            "user_id": current_user["id"]
-        }).sort("timestamp", 1).to_list(100)
-        
+        conversations = (
+            await db.conversations.find(
+                {"decision_id": decision_id, "user_id": current_user["id"]}
+            )
+            .sort("timestamp", 1)
+            .to_list(100)
+        )
+
         # Generate PDF
         pdf_data = await pdf_exporter.export_decision_to_pdf(
-            decision_data=decision,
-            conversations=conversations,
-            user_info=current_user
+            decision_data=decision, conversations=conversations, user_info=current_user
         )
-        
+
         # Create response with PDF
         from fastapi.responses import StreamingResponse
-        
+
         def generate_pdf():
             yield pdf_data
-        
+
         filename = f"decision-{decision_id[:8]}-{datetime.now().strftime('%Y%m%d')}.pdf"
-        
+
         return StreamingResponse(
             io.BytesIO(pdf_data),
             media_type="application/pdf",
-            headers={"Content-Disposition": f"attachment; filename={filename}"}
+            headers={"Content-Disposition": f"attachment; filename={filename}"},
         )
-        
+
     except Exception as e:
         logging.error(f"Error exporting PDF: {str(e)}")
-        raise HTTPException(status.HTTP_500_INTERNAL_SERVER_ERROR, f"Failed to export PDF: {str(e)}")
+        raise HTTPException(
+            status.HTTP_500_INTERNAL_SERVER_ERROR, f"Failed to export PDF: {str(e)}"
+        )
+
 
 @api_router.post("/decisions/{decision_id}/share")
 async def create_decision_share(
     decision_id: str,
     privacy_level: str = "link_only",
-    current_user: dict = Depends(get_current_user)
+    current_user: dict = Depends(get_current_user),
 ):
     """Create a shareable link for a decision"""
     try:
         # Validate privacy level
         if privacy_level not in ["public", "link_only"]:
             raise HTTPException(status.HTTP_400_BAD_REQUEST, "Invalid privacy level")
-        
+
         # Check if decision exists
-        decision = await db.decision_sessions.find_one({
-            "decision_id": decision_id,
-            "user_id": current_user["id"]
-        })
-        
+        decision = await db.decision_sessions.find_one(
+            {"decision_id": decision_id, "user_id": current_user["id"]}
+        )
+
         if not decision:
             raise HTTPException(status.HTTP_404_NOT_FOUND, "Decision not found")
-        
+
         # Create shareable link
         share_data = await sharing_service.create_shareable_link(
             decision_id=decision_id,
             user_id=current_user["id"],
-            privacy_level=privacy_level
+            privacy_level=privacy_level,
         )
-        
+
         return share_data
-        
+
     except Exception as e:
         logging.error(f"Error creating share: {str(e)}")
-        raise HTTPException(status.HTTP_500_INTERNAL_SERVER_ERROR, f"Failed to create share: {str(e)}")
+        raise HTTPException(
+            status.HTTP_500_INTERNAL_SERVER_ERROR, f"Failed to create share: {str(e)}"
+        )
+
 
 @api_router.get("/shared/{share_id}")
 async def get_shared_decision(share_id: str):
     """Get a shared decision by share ID (public endpoint)"""
     try:
         shared_data = await sharing_service.get_shared_decision(share_id)
-        
+
         if not shared_data:
-            raise HTTPException(status.HTTP_404_NOT_FOUND, "Shared decision not found or expired")
-        
+            raise HTTPException(
+                status.HTTP_404_NOT_FOUND, "Shared decision not found or expired"
+            )
+
         return shared_data
-        
+
     except Exception as e:
         logging.error(f"Error getting shared decision: {str(e)}")
-        raise HTTPException(status.HTTP_500_INTERNAL_SERVER_ERROR, "Failed to retrieve shared decision")
+        raise HTTPException(
+            status.HTTP_500_INTERNAL_SERVER_ERROR, "Failed to retrieve shared decision"
+        )
+
 
 @api_router.delete("/decisions/shares/{share_id}")
-async def revoke_decision_share(share_id: str, current_user: dict = Depends(get_current_user)):
+async def revoke_decision_share(
+    share_id: str, current_user: dict = Depends(get_current_user)
+):
     """Revoke a decision share"""
     try:
         success = await sharing_service.revoke_share(share_id, current_user["id"])
-        
+
         if not success:
             raise HTTPException(status.HTTP_404_NOT_FOUND, "Share not found")
-        
+
         return {"message": "Share revoked successfully"}
-        
+
     except Exception as e:
         logging.error(f"Error revoking share: {str(e)}")
-        raise HTTPException(status.HTTP_500_INTERNAL_SERVER_ERROR, "Failed to revoke share")
+        raise HTTPException(
+            status.HTTP_500_INTERNAL_SERVER_ERROR, "Failed to revoke share"
+        )
+
 
 @api_router.post("/decisions/compare")
 async def compare_decisions(
-    decision_ids: List[str],
-    current_user: dict = Depends(get_current_user)
+    decision_ids: List[str], current_user: dict = Depends(get_current_user)
 ):
     """Compare multiple decision sessions"""
     try:
         if len(decision_ids) < 2:
-            raise HTTPException(status.HTTP_400_BAD_REQUEST, "At least 2 decisions required for comparison")
-        
+            raise HTTPException(
+                status.HTTP_400_BAD_REQUEST,
+                "At least 2 decisions required for comparison",
+            )
+
         if len(decision_ids) > 5:
-            raise HTTPException(status.HTTP_400_BAD_REQUEST, "Cannot compare more than 5 decisions at once")
-        
+            raise HTTPException(
+                status.HTTP_400_BAD_REQUEST,
+                "Cannot compare more than 5 decisions at once",
+            )
+
         comparison_data = await comparison_service.compare_decisions(
-            decision_ids=decision_ids,
-            user_id=current_user["id"]
+            decision_ids=decision_ids, user_id=current_user["id"]
         )
-        
+
         return comparison_data
-        
+
     except Exception as e:
         logging.error(f"Error comparing decisions: {str(e)}")
-        raise HTTPException(status.HTTP_500_INTERNAL_SERVER_ERROR, f"Failed to compare decisions: {str(e)}")
+        raise HTTPException(
+            status.HTTP_500_INTERNAL_SERVER_ERROR,
+            f"Failed to compare decisions: {str(e)}",
+        )
+
 
 @api_router.get("/decisions/{decision_id}/shares")
-async def get_decision_shares(decision_id: str, current_user: dict = Depends(get_current_user)):
+async def get_decision_shares(
+    decision_id: str, current_user: dict = Depends(get_current_user)
+):
     """Get all shares for a decision"""
     try:
-        shares = await db.decision_shares.find({
-            "decision_id": decision_id,
-            "user_id": current_user["id"],
-            "is_active": True
-        }).to_list(10)
-        
+        shares = await db.decision_shares.find(
+            {
+                "decision_id": decision_id,
+                "user_id": current_user["id"],
+                "is_active": True,
+            }
+        ).to_list(10)
+
         # Clean up shares data
         for share in shares:
             if "_id" in share:
                 share["_id"] = str(share["_id"])
-        
+
         return {"shares": shares}
-        
+
     except Exception as e:
         logging.error(f"Error getting decision shares: {str(e)}")
-        raise HTTPException(status.HTTP_500_INTERNAL_SERVER_ERROR, "Failed to retrieve shares")
+        raise HTTPException(
+            status.HTTP_500_INTERNAL_SERVER_ERROR, "Failed to retrieve shares"
+        )
+
 
 # Account Security & Privacy Endpoints (Simplified)
 @api_router.post("/account/export-data")
@@ -3438,9 +4017,13 @@ async def export_user_data(current_user: dict = Depends(get_current_user)):
     """Export all user data for GDPR compliance (simplified)"""
     try:
         user = await db.users.find_one({"id": current_user["id"]})
-        decisions = await db.decision_sessions.find({"user_id": current_user["id"]}).to_list(None)
-        conversations = await db.conversations.find({"user_id": current_user["id"]}).to_list(None)
-        
+        decisions = await db.decision_sessions.find(
+            {"user_id": current_user["id"]}
+        ).to_list(None)
+        conversations = await db.conversations.find(
+            {"user_id": current_user["id"]}
+        ).to_list(None)
+
         # Remove sensitive data
         if user and "_id" in user:
             user["_id"] = str(user["_id"])
@@ -3450,21 +4033,25 @@ async def export_user_data(current_user: dict = Depends(get_current_user)):
         for c in conversations:
             if "_id" in c:
                 c["_id"] = str(c["_id"])
-        
+
         return {
             "user_profile": user,
             "decisions": decisions,
             "conversations": conversations,
-            "export_date": datetime.utcnow().isoformat()
+            "export_date": datetime.utcnow().isoformat(),
         }
     except Exception as e:
         logging.error(f"Error exporting user data: {str(e)}")
         raise HTTPException(status.HTTP_500_INTERNAL_SERVER_ERROR, "Data export failed")
 
+
 @api_router.post("/account/delete")
 async def delete_account(current_user: dict = Depends(get_current_user)):
     """Delete user account - placeholder"""
-    raise HTTPException(status.HTTP_501_NOT_IMPLEMENTED, "Account deletion not yet implemented")
+    raise HTTPException(
+        status.HTTP_501_NOT_IMPLEMENTED, "Account deletion not yet implemented"
+    )
+
 
 @api_router.get("/account/privacy-settings")
 async def get_privacy_settings(current_user: dict = Depends(get_current_user)):
@@ -3473,21 +4060,28 @@ async def get_privacy_settings(current_user: dict = Depends(get_current_user)):
         user = await db.users.find_one({"id": current_user["id"]})
         if not user:
             raise HTTPException(status.HTTP_404_NOT_FOUND, "User not found")
-        
+
         privacy_settings = user.get("privacy_settings", {})
-        
+
         return {
             "data_sharing": privacy_settings.get("data_sharing", False),
             "analytics_tracking": privacy_settings.get("analytics_tracking", True),
             "marketing_emails": privacy_settings.get("marketing_emails", False),
-            "security_notifications": privacy_settings.get("security_notifications", True)
+            "security_notifications": privacy_settings.get(
+                "security_notifications", True
+            ),
         }
     except Exception as e:
         logging.error(f"Error getting privacy settings: {str(e)}")
-        raise HTTPException(status.HTTP_500_INTERNAL_SERVER_ERROR, "Failed to get privacy settings")
+        raise HTTPException(
+            status.HTTP_500_INTERNAL_SERVER_ERROR, "Failed to get privacy settings"
+        )
+
 
 @api_router.put("/account/privacy-settings")
-async def update_privacy_settings(settings: PrivacySettings, current_user: dict = Depends(get_current_user)):
+async def update_privacy_settings(
+    settings: PrivacySettings, current_user: dict = Depends(get_current_user)
+):
     """Update user privacy settings"""
     try:
         await db.users.update_one(
@@ -3495,38 +4089,49 @@ async def update_privacy_settings(settings: PrivacySettings, current_user: dict 
             {
                 "$set": {
                     "privacy_settings": settings.dict(),
-                    "updated_at": datetime.utcnow()
+                    "updated_at": datetime.utcnow(),
                 }
-            }
+            },
         )
-        
+
         return {"message": "Privacy settings updated successfully"}
     except Exception as e:
         logging.error(f"Error updating privacy settings: {str(e)}")
-        raise HTTPException(status.HTTP_500_INTERNAL_SERVER_ERROR, "Failed to update privacy settings")
+        raise HTTPException(
+            status.HTTP_500_INTERNAL_SERVER_ERROR, "Failed to update privacy settings"
+        )
+
 
 @api_router.get("/account/security-log")
-async def get_security_log(current_user: dict = Depends(get_current_user), limit: int = 20):
+async def get_security_log(
+    current_user: dict = Depends(get_current_user), limit: int = 20
+):
     """Get user's security activity log"""
     try:
         # Get recent security events for this user
-        security_events = await db.audit_logs.find({
-            "user_id": current_user["id"]
-        }).sort("timestamp", -1).limit(limit).to_list(limit)
-        
+        security_events = (
+            await db.audit_logs.find({"user_id": current_user["id"]})
+            .sort("timestamp", -1)
+            .limit(limit)
+            .to_list(limit)
+        )
+
         # Clean sensitive data
         for event in security_events:
             if "_id" in event:
                 event["_id"] = str(event["_id"])
-            
+
             # Remove sensitive fields but keep relevant security info
             event.pop("requester_ip", None)
             event.pop("deletion_results", None)
-        
+
         return {"security_events": security_events}
     except Exception as e:
         logging.error(f"Error getting security log: {str(e)}")
-        raise HTTPException(status.HTTP_500_INTERNAL_SERVER_ERROR, "Failed to get security log")
+        raise HTTPException(
+            status.HTTP_500_INTERNAL_SERVER_ERROR, "Failed to get security log"
+        )
+
 
 # Privacy Policy and Terms Endpoints
 @api_router.get("/legal/privacy-policy")
@@ -3543,10 +4148,11 @@ async def get_privacy_policy():
                 "data_retention": "Decision data is retained until you delete your account.",
                 "user_rights": "You can export, modify, or delete your data at any time.",
                 "cookies": "We use essential cookies for authentication and functionality.",
-                "contact": "Contact privacy@choicepilot.ai for privacy-related questions."
-            }
+                "contact": "Contact privacy@choicepilot.ai for privacy-related questions.",
+            },
         }
     }
+
 
 @api_router.get("/legal/terms-of-service")
 async def get_terms_of_service():
@@ -3563,10 +4169,11 @@ async def get_terms_of_service():
                 "limitation_of_liability": "Service is provided as-is without warranties.",
                 "termination": "Either party may terminate the agreement at any time.",
                 "governing_law": "Agreement governed by laws of jurisdiction where service operates.",
-                "contact": "Contact legal@getgingee.com for legal questions."
-            }
+                "contact": "Contact legal@getgingee.com for legal questions.",
+            },
         }
     }
+
 
 # Security & Monitoring Endpoints
 @api_router.get("/admin/health")
@@ -3574,34 +4181,48 @@ async def get_system_health():
     """Get system health status (admin endpoint)"""
     return await system_monitor.check_system_health()
 
+
 @api_router.get("/admin/security-events")
-async def get_security_events(limit: int = 50, current_user: dict = Depends(get_current_user)):
+async def get_security_events(
+    limit: int = 50, current_user: dict = Depends(get_current_user)
+):
     """Get recent security events (admin only)"""
     # TODO: Add admin role check
     try:
-        events = await db.security_events.find().sort("timestamp", -1).limit(limit).to_list(limit)
-        
+        events = (
+            await db.security_events.find()
+            .sort("timestamp", -1)
+            .limit(limit)
+            .to_list(limit)
+        )
+
         # Clean up ObjectIds
         for event in events:
             if "_id" in event:
                 event["_id"] = str(event["_id"])
-        
+
         return {"security_events": events}
     except Exception as e:
         logger.error(f"Error getting security events: {str(e)}")
-        raise HTTPException(status.HTTP_500_INTERNAL_SERVER_ERROR, "Failed to retrieve security events")
+        raise HTTPException(
+            status.HTTP_500_INTERNAL_SERVER_ERROR, "Failed to retrieve security events"
+        )
+
 
 @api_router.get("/admin/performance-metrics")
 async def get_performance_metrics(hours: int = 24):
     """Get performance metrics for the last N hours"""
     try:
         since = datetime.utcnow() - timedelta(hours=hours)
-        
+
         # Get metrics from database
-        metrics = await db.performance_metrics.find({
-            "timestamp": {"$gte": since}
-        }).sort("timestamp", -1).limit(1000).to_list(1000)
-        
+        metrics = (
+            await db.performance_metrics.find({"timestamp": {"$gte": since}})
+            .sort("timestamp", -1)
+            .limit(1000)
+            .to_list(1000)
+        )
+
         # Calculate summary statistics
         if metrics:
             response_times = [m["response_time"] for m in metrics]
@@ -3611,12 +4232,12 @@ async def get_performance_metrics(hours: int = 24):
             error_rate = error_count / len(metrics) if metrics else 0
         else:
             avg_response_time = max_response_time = error_rate = 0
-        
+
         # Clean up ObjectIds
         for metric in metrics:
             if "_id" in metric:
                 metric["_id"] = str(metric["_id"])
-        
+
         return {
             "period_hours": hours,
             "total_requests": len(metrics),
@@ -3624,16 +4245,21 @@ async def get_performance_metrics(hours: int = 24):
             "max_response_time": round(max_response_time, 3),
             "error_rate": round(error_rate, 4),
             "error_count": error_count,
-            "metrics": metrics[:100]  # Return only recent 100 for display
+            "metrics": metrics[:100],  # Return only recent 100 for display
         }
     except Exception as e:
         logger.error(f"Error getting performance metrics: {str(e)}")
-        raise HTTPException(status.HTTP_500_INTERNAL_SERVER_ERROR, "Failed to retrieve performance metrics")
+        raise HTTPException(
+            status.HTTP_500_INTERNAL_SERVER_ERROR,
+            "Failed to retrieve performance metrics",
+        )
+
 
 @api_router.get("/admin/backup-status")
 async def get_backup_status():
     """Get backup status and recommendations"""
     return await backup_manager.get_backup_status()
+
 
 @api_router.post("/admin/audit-report")
 async def generate_audit_report(start_date: str, end_date: str):
@@ -3641,19 +4267,28 @@ async def generate_audit_report(start_date: str, end_date: str):
     try:
         start = datetime.fromisoformat(start_date)
         end = datetime.fromisoformat(end_date)
-        
+
         report = await audit_logger.generate_audit_report(start, end)
         return report
     except ValueError:
-        raise HTTPException(status.HTTP_400_BAD_REQUEST, "Invalid date format. Use ISO format: YYYY-MM-DD")
+        raise HTTPException(
+            status.HTTP_400_BAD_REQUEST,
+            "Invalid date format. Use ISO format: YYYY-MM-DD",
+        )
     except Exception as e:
         logger.error(f"Error generating audit report: {str(e)}")
-        raise HTTPException(status.HTTP_500_INTERNAL_SERVER_ERROR, "Failed to generate audit report")
+        raise HTTPException(
+            status.HTTP_500_INTERNAL_SERVER_ERROR, "Failed to generate audit report"
+        )
+
 
 # Legacy endpoints for compatibility
 @api_router.get("/")
 async def root():
-    return {"message": "ChoicePilot API - Your Personal AI Decision Assistant with Smart Monetization"}
+    return {
+        "message": "ChoicePilot API - Your Personal AI Decision Assistant with Smart Monetization"
+    }
+
 
 # Include the router in the main app
 app.include_router(api_router)
@@ -3666,20 +4301,19 @@ app.add_middleware(
     allow_methods=["GET", "POST", "PUT", "DELETE", "OPTIONS"],
     allow_headers=[
         "Authorization",
-        "Content-Type", 
+        "Content-Type",
         "X-Requested-With",
         "Accept",
         "Origin",
         "Access-Control-Request-Method",
-        "Access-Control-Request-Headers"
+        "Access-Control-Request-Headers",
     ],
     expose_headers=["Content-Disposition"],
 )
 
 # Configure logging
 logging.basicConfig(
-    level=logging.INFO,
-    format='%(asctime)s - %(name)s - %(levelname)s - %(message)s'
+    level=logging.INFO, format="%(asctime)s - %(name)s - %(levelname)s - %(message)s"
 )
 logger = logging.getLogger(__name__)
 
@@ -3689,9 +4323,13 @@ sys.path.append(os.path.dirname(os.path.abspath(__file__)))
 # Import AI Orchestrator after logger is defined
 try:
     from ai_orchestrator_v2 import (
-        create_ai_orchestrator, DecisionType, FollowUpQuestion, 
-        DecisionRecommendation, DecisionTrace
+        create_ai_orchestrator,
+        DecisionType,
+        FollowUpQuestion,
+        DecisionRecommendation,
+        DecisionTrace,
     )
+
     AI_ORCHESTRATOR_AVAILABLE = True
     logger.info("AI Orchestrator loaded successfully")
     # Create orchestrator instance with LLMRouter
@@ -3701,17 +4339,27 @@ except ImportError as e:
     AI_ORCHESTRATOR_AVAILABLE = False
     ai_orchestrator = None
 
+
 @api_router.get("/debug/ai-orchestrator")
 async def debug_ai_orchestrator():
     """Debug endpoint to check AI orchestrator status"""
     return {
         "ai_orchestrator_available": AI_ORCHESTRATOR_AVAILABLE,
         "ai_orchestrator_type": str(type(ai_orchestrator)),
-        "llm_router_available": hasattr(ai_orchestrator, "llm_router") if ai_orchestrator else False,
-        "classifier_available": hasattr(ai_orchestrator, "classifier") if ai_orchestrator else False,
-        "smart_router_available": hasattr(ai_orchestrator, "smart_router") if ai_orchestrator else False,
-        "followup_engine_available": hasattr(ai_orchestrator, "followup_engine") if ai_orchestrator else False
+        "llm_router_available": hasattr(ai_orchestrator, "llm_router")
+        if ai_orchestrator
+        else False,
+        "classifier_available": hasattr(ai_orchestrator, "classifier")
+        if ai_orchestrator
+        else False,
+        "smart_router_available": hasattr(ai_orchestrator, "smart_router")
+        if ai_orchestrator
+        else False,
+        "followup_engine_available": hasattr(ai_orchestrator, "followup_engine")
+        if ai_orchestrator
+        else False,
     }
+
 
 @app.on_event("shutdown")
 async def shutdown_db_client():


### PR DESCRIPTION
## Summary
- send account confirmation links via SMTP
- handle verification tokens in email service and account management
- verify token through new `/auth/confirm` endpoint
- trigger verification email on registration

## Testing
- `pytest -q` *(fails: Tunnel connection failed 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6855227ebe048332a471c288dac73ba1